### PR TITLE
[CLIPY-56][CLIPY-57] iOS 구조/검증 기준 정리

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,7 +31,7 @@
 필요 없는 항목은 지우지 말고 그대로 둡니다.
 
 - [ ] `mise exec -- tuist generate`
-- [ ] `./scripts/validate_ios_baseline.sh` 또는 `Docs/Open/SETUP.md`의 test command 확인
+- [ ] `./scripts/validate_ios_baseline.sh` 또는 필요한 경우 `CLIPY_IOS_VALIDATION_MODE=test ./scripts/validate_ios_baseline.sh` 확인
 - [ ] 화면 변경이 있으면 simulator에서 happy path 확인
 - [ ] 새 dependency가 있다면 추가 이유 확인
 - [ ] 생성된 `.xcodeproj`, `.xcworkspace`, `Derived/` 미포함 확인

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,7 +31,7 @@
 필요 없는 항목은 지우지 말고 그대로 둡니다.
 
 - [ ] `mise exec -- tuist generate`
-- [ ] `xcodebuild test ...` 또는 `Docs/Open/SETUP.md`의 test command 확인
+- [ ] `./scripts/validate_ios_baseline.sh` 또는 `Docs/Open/SETUP.md`의 test command 확인
 - [ ] 화면 변경이 있으면 simulator에서 happy path 확인
 - [ ] 새 dependency가 있다면 추가 이유 확인
 - [ ] 생성된 `.xcodeproj`, `.xcworkspace`, `Derived/` 미포함 확인

--- a/.github/workflows/ios-baseline.yml
+++ b/.github/workflows/ios-baseline.yml
@@ -1,0 +1,42 @@
+name: iOS Baseline
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/ios-baseline.yml"
+      - ".mise.toml"
+      - "Tuist.swift"
+      - "Workspace.swift"
+      - "Tuist/**"
+      - "Modules/**"
+      - "scripts/validate_ios_baseline.sh"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ios-baseline-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: macos-26
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install mise
+        run: |
+          curl https://mise.run | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install tools
+        run: |
+          mise trust --yes
+          mise install
+
+      - name: Validate iOS baseline
+        run: ./scripts/validate_ios_baseline.sh

--- a/Docs/Open/CODE_CONVENTIONS.md
+++ b/Docs/Open/CODE_CONVENTIONS.md
@@ -31,3 +31,92 @@ Modules/AppMain
 
 아직 필요하지 않은 module은 미리 만들지 않습니다.
 새 module을 추가할 때는 책임을 먼저 정하고, 의존 방향을 같이 정합니다.
+
+### Module 추가 기준
+
+새 module은 아래 조건이 맞을 때 추가합니다.
+
+- 실제 구현 작업에서 책임이 필요합니다.
+- module 책임을 한 문장으로 설명할 수 있습니다.
+- Tuist `Project.swift`, scheme, test target 기준을 함께 정할 수 있습니다.
+- 다른 작업 범위의 구현을 미리 당겨오지 않습니다.
+- 빈 target이나 빈 directory만 만들지 않습니다.
+
+### 기본 의존 방향
+
+```plaintext
+AppMain -> Feature -> Core
+AppMain -> Core
+Feature -x-> Feature
+Core -x-> Feature
+```
+
+`AppMain`은 app 실행과 조립을 맡습니다.
+제품 규칙, 저장, WebView primitive, 공용 UI primitive는 Core 계열에서 다룹니다.
+Home과 Session처럼 사용자가 만나는 흐름은 Feature 계열에서 다룹니다.
+
+Feature module끼리는 직접 의존하지 않습니다.
+공유가 필요하면 먼저 Core로 올릴 책임인지, 아니면 아직 같은 Feature 안에 있어도 되는지 봅니다.
+
+### DI 기준
+
+DIContainer는 `AppMain`에서 시작합니다.
+`AppMain`은 app의 composition root로 보고, Core 구현체와 Feature entry point를 조립합니다.
+
+Feature는 container를 직접 들고 다니지 않습니다.
+필요한 의존성은 initializer, factory, dependencies object로 받습니다.
+
+좋은 방향입니다:
+
+```swift
+let viewModel = HomeViewModel(
+    startNewSession: startNewSessionUseCase,
+    loadSessions: loadSessionsUseCase
+)
+```
+
+피할 방향입니다:
+
+```swift
+let viewModel = HomeViewModel(container: appDIContainer)
+```
+
+초기에는 별도 DI module을 만들지 않습니다.
+DI 타입이 여러 Feature에서 반복되고 `AppMain`만으로 조립 기준을 설명하기 어려워질 때만 작은 공유 module을 검토합니다.
+
+### Clean Architecture 기준
+
+Clean Architecture는 폴더 이름보다 의존 방향을 먼저 지킵니다.
+
+기본 흐름은 아래처럼 둡니다.
+
+```plaintext
+Feature UI
+  -> UseCase
+  -> Repository Protocol
+       <- Repository Implementation
+            -> Local DB / Web / Cache
+```
+
+`CoreDomain`은 entity, value object, 상태 전이 규칙, use case, repository protocol을 둡니다.
+`CorePersistence`는 repository 구현체와 record mapping을 둡니다.
+`CoreWeb`은 WebView, URL validation, capture 같은 platform primitive를 둡니다.
+
+Feature는 UIKit 화면과 사용자 action 처리에 집중합니다.
+Feature에서 local DB 구현체나 저장 schema를 직접 알지 않게 합니다.
+
+### Session 중심 구조
+
+Clipy는 Session 중심 앱입니다.
+Home은 세션 진입과 관리에 집중하고, 대부분의 탐색, 수집, 비교, 결정, 리뷰는 Session 안에서 처리합니다.
+
+그래서 아래 surface는 초기 기준에서 `FeatureSession` 책임으로 봅니다.
+
+- WebView surface
+- Contextual Overlay Actions
+- Comparison Bottom Sheet
+- Decision Screen
+- Overlay Editor
+
+`Decision Screen`과 `Overlay Editor`는 Session 내부 full-screen surface입니다.
+별도 app-level feature module로 먼저 분리하지 않습니다.

--- a/Docs/Open/PROJECT_STRUCTURE.md
+++ b/Docs/Open/PROJECT_STRUCTURE.md
@@ -26,6 +26,159 @@ Clipy-iOS/
 아직 Core/Feature module은 없습니다.
 module이 늘어나면 각 module은 자기 `Project.swift`를 가집니다.
 
+## Module 확장 방향
+
+Clipy는 Session 중심 앱입니다.
+Home은 세션 진입과 관리에 집중하고, 탐색, 수집, 비교, 결정, 리뷰는 대부분 Session 안에서 처리합니다.
+
+그래서 module은 화면 수를 그대로 따라가기보다 책임 경계를 기준으로 늘립니다.
+현재는 `AppMain`만 두고, 실제 구현 작업에서 책임이 분명해질 때 Core/Feature module을 추가합니다.
+
+예상 확장 방향은 아래와 같습니다.
+
+```plaintext
+Modules/
+  AppMain/
+  CoreDomain/
+  CorePersistence/
+  CoreWeb/
+  CoreUI/              # 공용 UIKit style/component가 필요해질 때만 추가
+  FeatureHome/
+  FeatureSession/
+```
+
+위 구조는 최종 확정 target 목록이 아닙니다.
+새 module은 해당 책임을 가진 실제 구현 작업이 열릴 때 만듭니다.
+
+## Module 책임
+
+| Module | 책임 |
+| --- | --- |
+| `AppMain` | app entry point, app 조립, scene lifecycle |
+| `CoreDomain` | Session, Item, Decision, Capture, 상태 전이 규칙 |
+| `CorePersistence` | local DB, repository 구현, SessionViewState 저장, image cache 연결 |
+| `CoreWeb` | WebView wrapper, URL validation, web page와 app 사이의 primitive |
+| `CoreUI` | typography, color, 공용 UIKit component. 필요해질 때만 추가 |
+| `FeatureHome` | Home, session list, start/reopen entry flow |
+| `FeatureSession` | Session screen, WebView surface, overlay actions, bottom sheet, Decision surface, Overlay Editor |
+
+`Decision Screen`과 `Overlay Editor`는 별도 app-level section이 아니라 Session 내부 surface로 봅니다.
+따라서 초기 기준에서는 `FeatureDecision`이나 `FeatureOverlayEditor`를 따로 만들지 않습니다.
+
+## 의존 방향
+
+기본 의존 방향은 아래처럼 둡니다.
+
+```plaintext
+AppMain -> Feature -> Core
+AppMain -> Core
+Feature -x-> Feature
+Core -x-> Feature
+```
+
+Feature끼리 직접 의존하지 않습니다.
+Feature 사이에 공유해야 하는 규칙이나 타입이 생기면 먼저 Core 책임인지 봅니다.
+
+## DI 조립 위치
+
+DIContainer는 `AppMain`에서 시작합니다.
+`AppMain`은 app의 composition root로 보고, Core 구현체와 Feature entry point를 조립합니다.
+
+```plaintext
+AppMain
+  ├ AppDIContainer
+  ├ FeatureHome factory
+  ├ FeatureSession factory
+  └ Core concrete instance wiring
+```
+
+Feature module은 `AppMain`을 알지 않습니다.
+Feature는 필요한 use case, repository protocol, factory를 initializer나 dependencies object로 받습니다.
+Core module도 `AppMain`을 알지 않습니다.
+
+초기에는 별도 `CoreDI` module을 만들지 않습니다.
+DI 관련 타입이 여러 Feature에서 반복되고 `AppMain`만으로 감당하기 어려워질 때만 작은 공유 module을 검토합니다.
+
+## Clean Architecture 방향
+
+Clipy의 Clean Architecture는 module 수를 먼저 늘리는 방식이 아니라, 의존 방향을 지키면서 필요한 layer를 나누는 방식으로 갑니다.
+
+기본 흐름은 아래와 같습니다.
+
+```plaintext
+Feature UI
+  -> UseCase
+  -> Repository Protocol
+       <- Repository Implementation
+            -> Local DB / Web / Cache
+```
+
+module 기준으로 보면 아래처럼 연결됩니다.
+
+```plaintext
+FeatureHome / FeatureSession -> CoreDomain
+CorePersistence -> CoreDomain
+FeatureSession -> CoreWeb
+AppMain -> FeatureHome / FeatureSession / CorePersistence / CoreWeb
+```
+
+`CoreDomain`은 entity, value object, 상태 전이 규칙, use case, repository protocol을 둡니다.
+`CorePersistence`는 repository 구현체와 record mapping을 둡니다.
+`CoreWeb`은 WebView와 URL 처리 같은 platform primitive를 둡니다.
+
+Feature는 UIKit 화면, ViewController, ViewModel, 화면 action 처리를 맡습니다.
+Feature에서 local DB 구현체를 직접 알지 않게 하고, `AppMain`에서 실제 구현체를 주입합니다.
+
+## 예상 code 배치
+
+각 module은 기본적으로 아래 구조를 가집니다.
+
+```plaintext
+Modules/<ModuleName>/
+  Project.swift
+  Sources/
+  Tests/
+```
+
+module 안쪽 폴더는 구현이 생길 때 작게 나눕니다.
+예상되는 배치는 아래 정도입니다.
+
+```plaintext
+CoreDomain/Sources/
+  Session/
+  Item/
+  Decision/
+  Capture/
+  State/
+  UseCases/
+  Repositories/
+
+CorePersistence/Sources/
+  Records/
+  Repositories/
+  ViewState/
+  ImageCache/
+
+CoreWeb/Sources/
+  WebView/
+  URL/
+  Capture/
+
+FeatureHome/Sources/
+  Home/
+  SessionList/
+
+FeatureSession/Sources/
+  Session/
+  BottomSheet/
+  OverlayActions/
+  Decision/
+  OverlayEditor/
+```
+
+처음부터 이 폴더를 모두 만들지는 않습니다.
+파일이 생기기 전의 빈 directory는 유지하지 않습니다.
+
 ## Tuist 기준 파일
 
 - `Workspace.swift`

--- a/Docs/Open/SETUP.md
+++ b/Docs/Open/SETUP.md
@@ -20,17 +20,17 @@ mise exec -- tuist generate
 
 ## Baseline 검증
 
-project 생성과 AppMain test를 한 번에 확인할 때는 아래 script를 씁니다.
+project 생성과 AppMain test build를 한 번에 확인할 때는 아래 script를 씁니다.
 
 ```sh
 ./scripts/validate_ios_baseline.sh
 ```
 
-script는 기본으로 사용 가능한 iPhone simulator를 찾아 `AppMain` scheme test를 실행합니다.
-필요하면 destination을 직접 지정할 수 있습니다.
+script는 기본으로 simulator를 띄우지 않는 `build-for-testing`을 실행합니다. PR CI에서는 이 빠른 기준선을 사용합니다.
+실제로 test를 실행해야 할 때는 `CLIPY_IOS_VALIDATION_MODE=test`를 지정합니다.
 
 ```sh
-CLIPY_IOS_DESTINATION='platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' \
+CLIPY_IOS_VALIDATION_MODE=test \
   ./scripts/validate_ios_baseline.sh
 ```
 
@@ -48,7 +48,7 @@ xcodebuild test \
 ## CI
 
 GitHub Actions에서는 `iOS Baseline` workflow가 같은 baseline script를 실행합니다.
-CI도 Tuist manifest를 기준으로 project를 생성하고 `AppMain` test를 확인합니다.
+CI도 Tuist manifest를 기준으로 project를 생성하고 `AppMain` test bundle이 build 가능한지 확인합니다. simulator를 띄우는 full test는 필요한 PR에서 `CLIPY_IOS_VALIDATION_MODE=test`로 별도 확인합니다.
 
 ## Generated files
 

--- a/Docs/Open/SETUP.md
+++ b/Docs/Open/SETUP.md
@@ -18,6 +18,22 @@ mise exec -- tuist version
 mise exec -- tuist generate
 ```
 
+## Baseline 검증
+
+project 생성과 AppMain test를 한 번에 확인할 때는 아래 script를 씁니다.
+
+```sh
+./scripts/validate_ios_baseline.sh
+```
+
+script는 기본으로 사용 가능한 iPhone simulator를 찾아 `AppMain` scheme test를 실행합니다.
+필요하면 destination을 직접 지정할 수 있습니다.
+
+```sh
+CLIPY_IOS_DESTINATION='platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' \
+  ./scripts/validate_ios_baseline.sh
+```
+
 ## Test
 
 ```sh
@@ -28,6 +44,11 @@ xcodebuild test \
 ```
 
 로컬에 같은 simulator가 없으면 설치된 iPhone simulator로 바꿔서 실행합니다.
+
+## CI
+
+GitHub Actions에서는 `iOS Baseline` workflow가 같은 baseline script를 실행합니다.
+CI도 Tuist manifest를 기준으로 project를 생성하고 `AppMain` test를 확인합니다.
 
 ## Generated files
 

--- a/scripts/validate_ios_baseline.sh
+++ b/scripts/validate_ios_baseline.sh
@@ -6,16 +6,16 @@ cd "$ROOT_DIR"
 
 SCHEME="${CLIPY_IOS_SCHEME:-AppMain}"
 WORKSPACE="${CLIPY_IOS_WORKSPACE:-Clipy.xcworkspace}"
+MODE="${CLIPY_IOS_VALIDATION_MODE:-build-for-testing}"
 DESTINATION="${CLIPY_IOS_DESTINATION:-}"
+XCODEBUILD_ARGS=()
 
-echo "Xcode:"
-xcodebuild -version
+if [[ "${CLIPY_XCODEBUILD_QUIET:-1}" == "1" ]]; then
+  XCODEBUILD_ARGS+=("-quiet")
+fi
 
-echo "Tuist:"
-mise exec -- tuist version
-
-if [[ -z "$DESTINATION" ]]; then
-  DEVICE_ID="$(xcrun simctl list devices available --json | python3 -c '
+resolve_test_destination() {
+  xcrun simctl list devices available --json | python3 -c '
 import json
 import sys
 
@@ -34,14 +34,41 @@ if selected is None:
     raise SystemExit("No available iPhone simulator found.")
 
 print(selected["udid"])
-')"
-  DESTINATION="platform=iOS Simulator,id=${DEVICE_ID}"
-fi
+'
+}
+
+echo "Xcode:"
+xcodebuild -version
+
+echo "Tuist:"
+mise exec -- tuist version
+
+echo "Validation mode: ${MODE}"
+
+case "$MODE" in
+  build-for-testing|build)
+    ACTION="build-for-testing"
+    DESTINATION="${DESTINATION:-generic/platform=iOS Simulator}"
+    ;;
+  test)
+    ACTION="test"
+    if [[ -z "$DESTINATION" ]]; then
+      DEVICE_ID="$(resolve_test_destination)"
+      DESTINATION="platform=iOS Simulator,id=${DEVICE_ID},arch=arm64"
+    fi
+    ;;
+  *)
+    echo "Unsupported CLIPY_IOS_VALIDATION_MODE: ${MODE}" >&2
+    echo "Use one of: build-for-testing, build, test" >&2
+    exit 2
+    ;;
+esac
 
 echo "Using destination: ${DESTINATION}"
 
 mise exec -- tuist generate
-xcodebuild test \
+xcodebuild "$ACTION" \
   -workspace "$WORKSPACE" \
   -scheme "$SCHEME" \
-  -destination "$DESTINATION"
+  -destination "$DESTINATION" \
+  "${XCODEBUILD_ARGS[@]}"

--- a/scripts/validate_ios_baseline.sh
+++ b/scripts/validate_ios_baseline.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+SCHEME="${CLIPY_IOS_SCHEME:-AppMain}"
+WORKSPACE="${CLIPY_IOS_WORKSPACE:-Clipy.xcworkspace}"
+DESTINATION="${CLIPY_IOS_DESTINATION:-}"
+
+echo "Xcode:"
+xcodebuild -version
+
+echo "Tuist:"
+mise exec -- tuist version
+
+if [[ -z "$DESTINATION" ]]; then
+  DEVICE_ID="$(xcrun simctl list devices available --json | python3 -c '
+import json
+import sys
+
+payload = json.load(sys.stdin)
+devices = [
+    device
+    for runtime_devices in payload.get("devices", {}).values()
+    for device in runtime_devices
+    if device.get("isAvailable") and device.get("name", "").startswith("iPhone")
+]
+
+preferred = next((device for device in devices if device.get("name") == "iPhone 17 Pro"), None)
+selected = preferred or (devices[0] if devices else None)
+
+if selected is None:
+    raise SystemExit("No available iPhone simulator found.")
+
+print(selected["udid"])
+')"
+  DESTINATION="platform=iOS Simulator,id=${DEVICE_ID}"
+fi
+
+echo "Using destination: ${DESTINATION}"
+
+mise exec -- tuist generate
+xcodebuild test \
+  -workspace "$WORKSPACE" \
+  -scheme "$SCHEME" \
+  -destination "$DESTINATION"


### PR DESCRIPTION
 ## 무엇을 바꿨나요?

  - Tuist 기준 iOS module / directory 구조 기준을 문서화했습니다.
  - 현재 단계에서는 `AppMain`만 유지하고, Core / Feature module은 실제 제품 코드가 생기는 시점에 분리하도록 기준을 정리했습니다.
  - AppMain / Core / Feature 경계 기준과 DI 조립 시 위치를 정리했습니다.
  - 로컬과 GitHub Actions에서 같은 흐름으로 확인할 수 있는 검증 스크립트를 추가했습니다.

  ## 왜 바꿨나요?

  Clipy iOS 앱이 앞으로 Session, WebView, Bottom Sheet, Persistence 기능으로 커지기 전에, module을 언제 나누고 어떤 방향으로 의존할지에 대한 기준이 필요했습니다.
다만 아직 제품 코드가 충분히 쌓이지 않은 상태라서, 미리 많은 module을 만들기보다는 `AppMain` 중심으로 시작하고 필요한 시점에 Core / Feature module을 추가하는 방향으로 정리했습니다.
또한 PR마다 최소한의 생성/테스트 흐름을 같은 명령으로 확인할 수 있도록 검증 기준을 추가했습니다.

## 변경 범위

  - iOS module / directory 구조 기준
  - AppMain / Core / Feature 책임 경계
  - DIContainer / Clean Architecture 방향
  - iOS baseline 검증 script
  - GitHub Actions baseline CI
  - 공개 개발 문서 보강

  ## 제외한 범위

  - Core / Feature module 실제 생성, SwiftLint / CodeRabbit / Jira-Confluence 자동화, 배포 lane 구성도 다음 작업으로 넘겼습니다.
  - 특히 SwiftLint와 CodeRabbit은 지금 바로 도입하지 않고, 앞으로 제품 코드를 작성하면서 필요한 lint / review rule 후보를 `Docs/Team` 쪽에 기록한 뒤 실제 module 구조가 드러나는 시점에 함께 도입합니다.
  - CI는 이번 PR에서 빠른 검증까지만 진행합니다. iOS CI는 simulator 실행과 Xcode cold cache 비용이 커서, 추후 제품 코드와 module이 늘어나면 module별 script / workflow 분리가 필요합니다.
  - Core / Feature module이 실제로 생기는 시점에 PR fast check, integration check, full regression check를 나누는 방향으로 확장할 예정입니다.


  ## 확인한 내용

  - [x] `mise exec -- tuist generate`
  - [x] `./scripts/validate_ios_baseline.sh` 또는 `Docs/Open/SETUP.md`의 test command 확인
  - [x] 생성된 `.xcodeproj`, `.xcworkspace`, `Derived/` 미포함 확인

  ## 테스트와 문서

  - `./scripts/validate_ios_baseline.sh`로 Tuist generate와 AppMain test 흐름을 확인했습니다.
  - `Docs/Open/PROJECT_STRUCTURE.md`에 module / directory 구조 기준을 정리했습니다.
  - `Docs/Open/CODE_CONVENTIONS.md`에 module 책임 경계와 DI 기준을 보강했습니다.
  - `Docs/Open/SETUP.md`에 baseline 검증 명령을 추가했습니다.

  ## 관련 이슈

  Closes #3
  Closes #4
  Related: CLIPY-56, CLIPY-57
