### PR TITLE
[CLIPY-58] CoreDomain 도메인 모델 초기 구성

### DIFF
--- a/Modules/CoreDomain/Project.swift
+++ b/Modules/CoreDomain/Project.swift
@@ -1,0 +1,14 @@
+//
+//  Project.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = ClipyModuleFactory.makeFramework(
+    name: "CoreDomain",
+    bundleIdSuffix: "core-domain"
+)

--- a/Modules/CoreDomain/Sources/Capture/Capture.swift
+++ b/Modules/CoreDomain/Sources/Capture/Capture.swift
@@ -1,0 +1,30 @@
+//
+//  Capture.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import Foundation
+
+public struct Capture: Equatable {
+    public let id: UUID
+    public let itemId: UUID
+    public let imageRef: ImageRef
+    public let capturedAt: Date
+    public let memo: String?
+
+    public init(
+        id: UUID,
+        itemId: UUID,
+        imageRef: ImageRef,
+        capturedAt: Date,
+        memo: String? = nil
+    ) {
+        self.id = id
+        self.itemId = itemId
+        self.imageRef = imageRef
+        self.capturedAt = capturedAt
+        self.memo = memo
+    }
+}

--- a/Modules/CoreDomain/Sources/Decision/Decision.swift
+++ b/Modules/CoreDomain/Sources/Decision/Decision.swift
@@ -1,0 +1,27 @@
+//
+//  Decision.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import Foundation
+
+public struct Decision: Equatable {
+    public let id: UUID
+    public let sessionId: UUID
+    public let itemId: UUID
+    public let decidedAt: Date
+
+    public init(
+        id: UUID,
+        sessionId: UUID,
+        itemId: UUID,
+        decidedAt: Date
+    ) {
+        self.id = id
+        self.sessionId = sessionId
+        self.itemId = itemId
+        self.decidedAt = decidedAt
+    }
+}

--- a/Modules/CoreDomain/Sources/Item/Item.swift
+++ b/Modules/CoreDomain/Sources/Item/Item.swift
@@ -1,0 +1,54 @@
+//
+//  Item.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import Foundation
+
+public struct Item: Equatable {
+    public let id: UUID
+    public let sessionId: UUID
+    public let sourceUrl: String
+    public let productName: String?
+    public let priceSnapshot: MoneySnapshot?
+    public let thumbnailImage: ImageRef?
+    public let note: String?
+    public let intentState: ItemIntentState
+    public let captures: [Capture]
+    public let createdAt: Date
+    public let updatedAt: Date
+
+    public init(
+        id: UUID,
+        sessionId: UUID,
+        sourceUrl: String,
+        productName: String? = nil,
+        priceSnapshot: MoneySnapshot? = nil,
+        thumbnailImage: ImageRef? = nil,
+        note: String? = nil,
+        intentState: ItemIntentState,
+        captures: [Capture] = [],
+        createdAt: Date,
+        updatedAt: Date
+    ) {
+        self.id = id
+        self.sessionId = sessionId
+        self.sourceUrl = sourceUrl
+        self.productName = productName
+        self.priceSnapshot = priceSnapshot
+        self.thumbnailImage = thumbnailImage
+        self.note = note
+        self.intentState = intentState
+        self.captures = captures
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+public enum ItemIntentState: String, Equatable, CaseIterable {
+    case interested = "Interested"
+    case hold = "Hold"
+    case dropped = "Dropped"
+}

--- a/Modules/CoreDomain/Sources/Session/Session.swift
+++ b/Modules/CoreDomain/Sources/Session/Session.swift
@@ -1,0 +1,50 @@
+//
+//  Session.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import Foundation
+
+public struct Session: Equatable {
+    public let id: UUID
+    public let name: String?
+    public let status: SessionStatus
+    public let createdAt: Date
+    public let updatedAt: Date
+    public let closedAt: Date?
+    public let abandonedAt: Date?
+    public let items: [Item]
+    public let decisions: [Decision]
+
+    public init(
+        id: UUID,
+        name: String? = nil,
+        status: SessionStatus,
+        createdAt: Date,
+        updatedAt: Date,
+        closedAt: Date? = nil,
+        abandonedAt: Date? = nil,
+        items: [Item] = [],
+        decisions: [Decision] = []
+    ) {
+        self.id = id
+        self.name = name
+        self.status = status
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.closedAt = closedAt
+        self.abandonedAt = abandonedAt
+        self.items = items
+        self.decisions = decisions
+    }
+}
+
+public enum SessionStatus: String, Equatable, CaseIterable {
+    case draft = "Draft"
+    case collecting = "Collecting"
+    case pending = "Pending"
+    case decided = "Decided"
+    case abandoned = "Abandoned"
+}

--- a/Modules/CoreDomain/Sources/ValueObjects/ImageRef.swift
+++ b/Modules/CoreDomain/Sources/ValueObjects/ImageRef.swift
@@ -1,0 +1,19 @@
+//
+//  ImageRef.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+public struct ImageRef: Equatable {
+    public let remoteUrl: String
+    public let localPath: String?
+
+    public init(
+        remoteUrl: String,
+        localPath: String? = nil
+    ) {
+        self.remoteUrl = remoteUrl
+        self.localPath = localPath
+    }
+}

--- a/Modules/CoreDomain/Sources/ValueObjects/MoneySnapshot.swift
+++ b/Modules/CoreDomain/Sources/ValueObjects/MoneySnapshot.swift
@@ -1,0 +1,24 @@
+//
+//  MoneySnapshot.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import Foundation
+
+public struct MoneySnapshot: Equatable {
+    public let amount: Decimal
+    public let currency: String
+    public let rawText: String?
+
+    public init(
+        amount: Decimal,
+        currency: String,
+        rawText: String? = nil
+    ) {
+        self.amount = amount
+        self.currency = currency
+        self.rawText = rawText
+    }
+}

--- a/Modules/CoreDomain/Tests/DomainModelContractTests.swift
+++ b/Modules/CoreDomain/Tests/DomainModelContractTests.swift
@@ -1,0 +1,88 @@
+//
+//  DomainModelBaselineTests.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import XCTest
+import CoreDomain
+
+// 이 suite는 다른 모듈들이 함께 쓰는 public domain contract를 고정합니다.
+// 내부 동작을 직접 검증해야 한다면 별도 test suite에서 @testable import를 검토합니다.
+
+final class DomainModelContractTests: XCTestCase {
+    func test_draftSession_hasNoItemsOrDecisions_asEmptyComparisonContext() {
+        let session = Session(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+            status: .draft,
+            createdAt: .fixedNow,
+            updatedAt: .fixedNow
+        )
+
+        XCTAssertEqual(session.status, .draft)
+        XCTAssertTrue(session.items.isEmpty)
+        XCTAssertTrue(session.decisions.isEmpty)
+    }
+
+    func test_decidedSession_linksDecisionToSelectedItem_preservingItemContext() {
+        let sessionId = UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+        let itemId = UUID(uuidString: "00000000-0000-0000-0000-000000000003")!
+        let capture = Capture(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000004")!,
+            itemId: itemId,
+            imageRef: ImageRef(remoteUrl: "https://example.com/images/item.png"),
+            capturedAt: .fixedNow
+        )
+        let item = Item(
+            id: itemId,
+            sessionId: sessionId,
+            sourceUrl: "https://example.com/products/clipy-case",
+            note: "Lightweight option",
+            intentState: .interested,
+            captures: [capture],
+            createdAt: .fixedNow,
+            updatedAt: .fixedNow
+        )
+        let decision = Decision(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000005")!,
+            sessionId: sessionId,
+            itemId: itemId,
+            decidedAt: .fixedNow
+        )
+
+        let session = Session(
+            id: sessionId,
+            name: "Travel bag",
+            status: .decided,
+            createdAt: .fixedNow,
+            updatedAt: .fixedNow,
+            items: [item],
+            decisions: [decision]
+        )
+
+        XCTAssertEqual(session.items.map(\.sessionId), [session.id])
+        XCTAssertEqual(session.items.flatMap(\.captures).map(\.itemId), [itemId])
+        XCTAssertEqual(session.decisions.map(\.itemId), [itemId])
+        XCTAssertEqual(session.items.first?.note, "Lightweight option")
+    }
+
+    func test_domainStates_keepStableStoredValues_forLocalRestore() {
+        XCTAssertEqual(SessionStatus.allCases.map(\.rawValue), [
+            "Draft",
+            "Collecting",
+            "Pending",
+            "Decided",
+            "Abandoned"
+        ])
+        XCTAssertEqual(ItemIntentState.allCases.map(\.rawValue), [
+            "Interested",
+            "Hold",
+            "Dropped"
+        ])
+    }
+}
+
+private extension Date {
+    static let fixedNow = Date(timeIntervalSince1970: 0)
+}

--- a/Tuist/ProjectDescriptionHelpers/ClipyModuleFactory.swift
+++ b/Tuist/ProjectDescriptionHelpers/ClipyModuleFactory.swift
@@ -49,6 +49,48 @@ public enum ClipyModuleFactory {
         )
     }
 
+    public static func makeFramework(
+        name: String,
+        bundleIdSuffix: String,
+        dependencies: [TargetDependency] = [],
+        hasTests: Bool = true
+    ) -> Project {
+        var targets: [Target] = [
+            .target(
+                name: name,
+                destinations: ClipyProjectConfig.defaultDestinations,
+                product: .framework,
+                bundleId: "\(ClipyProjectConfig.bundleIdPrefix).\(bundleIdSuffix)",
+                deploymentTargets: ClipyProjectConfig.deploymentTargets,
+                infoPlist: .default,
+                sources: ["\(ClipyProjectConfig.sourcesDirectory)/**"],
+                dependencies: dependencies
+            )
+        ]
+
+        if hasTests {
+            targets.append(
+                .target(
+                    name: "\(name)Tests",
+                    destinations: ClipyProjectConfig.defaultDestinations,
+                    product: .unitTests,
+                    bundleId: "\(ClipyProjectConfig.bundleIdPrefix).\(bundleIdSuffix).tests",
+                    deploymentTargets: ClipyProjectConfig.deploymentTargets,
+                    infoPlist: .default,
+                    sources: ["\(ClipyProjectConfig.testsDirectory)/**"],
+                    dependencies: [.target(name: name)]
+                )
+            )
+        }
+
+        return Project(
+            name: name,
+            options: .options(automaticSchemesOptions: .disabled),
+            targets: targets,
+            schemes: [makeScheme(name: name, hasTests: hasTests)]
+        )
+    }
+
     private static func makeScheme(name: String, hasTests: Bool) -> Scheme {
         Scheme.scheme(
             name: name,

--- a/Workspace.swift
+++ b/Workspace.swift
@@ -10,6 +10,7 @@ import ProjectDescription
 let workspace = Workspace(
     name: "Clipy",
     projects: [
-        "Modules/AppMain"
+        "Modules/AppMain",
+        "Modules/CoreDomain"
     ]
 )


### PR DESCRIPTION
  ## 무엇을 바꿨나요?

  - `CoreDomain` module을 추가했습니다.
  - Session / Item / Decision / Capture 도메인 모델을 추가했습니다.
  - SessionStatus, ItemIntentState, MoneySnapshot, ImageRef를 추가했습니다.
  - 도메인 모델의 인터페이스를 검증하는 `DomainModelContractTests`를 추가했습니다.
  - Tuist workspace와 framework module 생성 helper를 보강했습니다.

  ## 왜 바꿨나요?

  CLIPY-31의 persistence 작업을 진행하려면 Local DB schema와 SessionViewState 저장 구조가 공통으로 참조할 iOS 도메인 모델이 먼저 필요합니다.

  이번 PR은 CLIPY-58 범위에 맞춰 저장 구현 전에 필요한 CoreDomain 초기 구조를 구성합니다.

  ## 변경 범위

  - CoreDomain Tuist module
  - Domain entity / value object
  - CoreDomainTests
  - Workspace / Tuist module factory

  ## 테스트 기준

  - CoreDomainTests는 `@testable import`를 쓰지 않고 public API 기준으로 검증합니다.
  - 이번 테스트는 module 내부 구현이 아니라 AppMain / Feature / Persistence가 함께 참조할 도메인 계약을 고정하는 목적입니다.
  - 이후 internal policy나 mapper처럼 module 내부 규칙을 직접 검증해야 하는 테스트에서는 별도 test suite에서 `@testable import` 사용을 검토할 수 있습니다.

  ## 제외한 범위

  - Local DB schema
  - repository 구현
  - SessionViewState 저장 구조
  - UI / WebView / BottomSheet 연결
  - Android / QA task
  - Docs/Open 문서 정리

  ## 확인한 내용

- [x] `mise exec -- tuist generate`
- [x] `./scripts/validate_ios_baseline.sh` 또는 필요한 경우 `CLIPY_IOS_VALIDATION_MODE=test ./scripts/validate_ios_baseline.sh` 확인

  ## 관련 이슈

  Closes #6
  Related: CLIPY-58, CLIPY-31
