### PR TITLE
[CLIPY-59][CLIPY-60] Local DB 저장 구조 작성

### DIFF
--- a/Docs/Open/PROJECT_STRUCTURE.md
+++ b/Docs/Open/PROJECT_STRUCTURE.md
@@ -20,6 +20,11 @@ Clipy-iOS/
       Project.swift
       Sources/
       Tests/
+    CorePersistence/
+      Project.swift
+      Resources/
+      Sources/
+      Tests/
 ```
 
 ## 현재 module
@@ -27,7 +32,8 @@ Clipy-iOS/
 | Module | 책임 |
 | --- | --- |
 | `AppMain` | app entry point, scene lifecycle, app 조립 |
-| `CoreDomain` | Session, Item, Decision, Capture와 상태 전이 규칙 |
+| `CoreDomain` | Session, Item, Decision, Capture, SessionSnapshot와 repository contract |
+| `CorePersistence` | CoreData 기반 local 저장 구조, entity mapping, repository 구현 |
 
 module이 늘어나도 기본 구조는 같습니다.
 각 module은 자기 `Project.swift`, `Sources/`, `Tests/`를 가집니다.
@@ -48,7 +54,17 @@ Module은 화면 수가 아니라 책임 경계를 기준으로 늘립니다.
 
 ## 의존 방향
 
-기본 의존 방향은 아래처럼 둡니다.
+현재 module 의존은 아래처럼 둡니다.
+
+```plaintext
+AppMain -> CorePersistence -> CoreDomain
+```
+
+`AppMain`은 app entry point와 composition root를 맡습니다.
+`CorePersistence`는 `CoreDomain`의 repository contract를 CoreData로 구현합니다.
+`CoreDomain`은 저장소 구현, WebView, UIKit detail을 모릅니다.
+
+Feature module이 생기면 기본 의존 방향은 아래처럼 둡니다.
 
 ```plaintext
 AppMain -> Feature -> Core
@@ -56,10 +72,6 @@ AppMain -> Core
 Feature -x-> Feature
 Core -x-> Feature
 ```
-
-`AppMain`은 app의 composition root입니다.
-Feature module은 `AppMain`을 알지 않습니다.
-Core module도 `AppMain`이나 Feature를 알지 않습니다.
 
 Feature끼리는 직접 의존하지 않습니다.
 공유해야 하는 규칙이나 타입이 생기면 먼저 Core 책임인지 봅니다.
@@ -104,7 +116,10 @@ Feature UI
             -> Local DB / Web / Cache
 ```
 
-`CoreDomain`은 entity, value object, 상태 전이 규칙, use case, repository protocol을 둡니다.
+현재 `CoreDomain`은 entity, value object, `SessionViewState`, `SessionSnapshot`, repository protocol 같은 제품 상태 계약을 둡니다.
+상태 전이 규칙과 use case는 해당 Feature 작업에서 실제 필요가 생길 때 추가합니다.
+
+`CorePersistence`는 CoreData schema, entity mapping, `SessionRepository` 구현을 맡습니다.
 Persistence, WebView, cache 같은 platform detail은 Domain 안으로 들어오지 않습니다.
 
 Feature는 UIKit 화면, ViewController, ViewModel, 화면 action 처리를 맡습니다.
@@ -121,7 +136,6 @@ Home은 세션 진입과 관리에 집중합니다.
 
 | 책임 | 예시 module |
 | --- | --- |
-| local 저장소와 record mapping | `CorePersistence` |
 | WebView, URL validation, web primitive | `CoreWeb` |
 | 공용 UIKit style/component | `CoreUI` |
 | Home, session list, start/reopen entry flow | `FeatureHome` |

--- a/Docs/Open/SETUP.md
+++ b/Docs/Open/SETUP.md
@@ -20,16 +20,17 @@ mise exec -- tuist generate
 
 ## Baseline 검증
 
-project 생성과 AppMain test build를 한 번에 확인할 때는 아래 script를 씁니다.
+project 생성과 기본 app scheme build를 한 번에 확인할 때는 아래 script를 씁니다.
 
 ```sh
 ./scripts/validate_ios_baseline.sh
 ```
 
-script는 기본으로 simulator를 띄우지 않는 `build-for-testing`을 실행합니다.
-PR CI에서는 이 빠른 기준선을 사용합니다.
+script는 기본으로 `AppMain` scheme의 `build-for-testing`을 실행합니다.
+simulator를 띄우지 않아서 빠르게 확인할 수 있습니다.
+AppMain이 의존하는 module도 이 흐름에서 함께 build됩니다.
 
-실제로 test를 실행해야 할 때는 `CLIPY_IOS_VALIDATION_MODE=test`를 지정합니다.
+실제로 test를 실행해야 할 때는 `CLIPY_IOS_VALIDATION_MODE=test`를 같이 지정합니다.
 
 ```sh
 CLIPY_IOS_VALIDATION_MODE=test \
@@ -37,6 +38,8 @@ CLIPY_IOS_VALIDATION_MODE=test \
 ```
 
 ## Test
+
+test를 직접 실행할 때는 AppMain scheme을 지정합니다.
 
 ```sh
 xcodebuild test \
@@ -51,8 +54,7 @@ xcodebuild test \
 
 GitHub Actions에서는 `iOS Baseline` workflow가 같은 baseline script를 실행합니다.
 CI도 Tuist manifest를 기준으로 project를 생성합니다.
-그 다음 `AppMain` test bundle이 build 가능한지 확인합니다.
-
+현재 기본 CI는 `AppMain` build-for-testing까지 확인합니다.
 simulator를 띄우는 full test는 필요한 PR에서 `CLIPY_IOS_VALIDATION_MODE=test`로 별도 확인합니다.
 
 ## Generated files

--- a/Modules/AppMain/Project.swift
+++ b/Modules/AppMain/Project.swift
@@ -10,5 +10,8 @@ import ProjectDescriptionHelpers
 
 let project = ClipyModuleFactory.makeApp(
     name: "AppMain",
-    bundleIdSuffix: "app"
+    bundleIdSuffix: "app",
+    dependencies: [
+        .project(target: "CorePersistence", path: .relativeToRoot("Modules/CorePersistence"))
+    ]
 )

--- a/Modules/AppMain/Tests/AppMainBaselineTests.swift
+++ b/Modules/AppMain/Tests/AppMainBaselineTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+
 @testable import AppMain
 
 final class AppMainBaselineTests: XCTestCase {

--- a/Modules/CoreDomain/Sources/Repositories/SessionRepository.swift
+++ b/Modules/CoreDomain/Sources/Repositories/SessionRepository.swift
@@ -1,0 +1,13 @@
+//
+//  SessionRepository.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import Foundation
+
+public protocol SessionRepository {
+    func save(_ snapshot: SessionSnapshot) async throws
+    func loadSession(id: UUID) async throws -> SessionSnapshot?
+}

--- a/Modules/CoreDomain/Sources/Session/SessionSnapshot.swift
+++ b/Modules/CoreDomain/Sources/Session/SessionSnapshot.swift
@@ -1,0 +1,16 @@
+//
+//  SessionSnapshot.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+public struct SessionSnapshot: Equatable {
+    public let session: Session
+    public let viewState: SessionViewState?
+
+    public init(session: Session, viewState: SessionViewState? = nil) {
+        self.session = session
+        self.viewState = viewState
+    }
+}

--- a/Modules/CoreDomain/Sources/Session/SessionViewState.swift
+++ b/Modules/CoreDomain/Sources/Session/SessionViewState.swift
@@ -1,0 +1,55 @@
+//
+//  SessionViewState.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import Foundation
+
+public struct SessionViewState: Equatable {
+    public let sessionId: UUID
+    public let lastWebUrl: String?
+    public let bottomSheetState: BottomSheetState
+    public let lastOpenedAt: Date
+
+    public init(
+        sessionId: UUID,
+        lastWebUrl: String? = nil,
+        bottomSheetState: BottomSheetState,
+        lastOpenedAt: Date
+    ) {
+        self.sessionId = sessionId
+        self.lastWebUrl = lastWebUrl
+        self.bottomSheetState = bottomSheetState
+        self.lastOpenedAt = lastOpenedAt
+    }
+
+    public func resolvedUIState(decisionCount: Int) -> SessionUIState {
+        let hasDecision = decisionCount > 0
+
+        switch (hasDecision, bottomSheetState) {
+        case (false, .expanded):
+            return .comparing
+        case (true, .expanded):
+            return .reviewComparing
+        case (false, .hidden), (false, .peek):
+            return .browsing
+        case (true, .hidden), (true, .peek):
+            return .reviewBrowsing
+        }
+    }
+}
+
+public enum BottomSheetState: String, Equatable, CaseIterable {
+    case hidden = "Hidden"
+    case peek = "Peek"
+    case expanded = "Expanded"
+}
+
+public enum SessionUIState: String, Equatable, CaseIterable {
+    case browsing = "Browsing"
+    case comparing = "Comparing"
+    case reviewBrowsing = "ReviewBrowsing"
+    case reviewComparing = "ReviewComparing"
+}

--- a/Modules/CoreDomain/Tests/DomainModelContractTests.swift
+++ b/Modules/CoreDomain/Tests/DomainModelContractTests.swift
@@ -1,11 +1,12 @@
 //
-//  DomainModelBaselineTests.swift
+//  DomainModelContractTests.swift
 //  Clipy
 //
 //  Created by 박민서 on 5/5/26.
 //
 
 import XCTest
+
 import CoreDomain
 
 // 이 suite는 다른 모듈들이 함께 쓰는 public domain contract를 고정합니다.

--- a/Modules/CoreDomain/Tests/SessionViewStateContractTests.swift
+++ b/Modules/CoreDomain/Tests/SessionViewStateContractTests.swift
@@ -1,0 +1,72 @@
+//
+//  SessionViewStateContractTests.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import XCTest
+
+import CoreDomain
+
+final class SessionViewStateContractTests: XCTestCase {
+    func test_expandedBottomSheet_withoutDecision_resolvesComparing_forPendingReentry() {
+        let viewState = SessionViewState(
+            sessionId: .fixedSession,
+            lastWebUrl: "https://example.com/products/clipy-case",
+            bottomSheetState: .expanded,
+            lastOpenedAt: .fixedNow
+        )
+
+        XCTAssertEqual(viewState.resolvedUIState(decisionCount: 0), .comparing)
+    }
+
+    func test_expandedBottomSheet_withDecision_resolvesReviewComparing_forDecidedReentry() {
+        let viewState = SessionViewState(
+            sessionId: .fixedSession,
+            lastWebUrl: "https://example.com/products/clipy-case",
+            bottomSheetState: .expanded,
+            lastOpenedAt: .fixedNow
+        )
+
+        XCTAssertEqual(viewState.resolvedUIState(decisionCount: 1), .reviewComparing)
+    }
+
+    func test_hiddenOrPeekBottomSheet_resolvesBrowsingStates_forStoredViewState() {
+        let hidden = SessionViewState(
+            sessionId: .fixedSession,
+            bottomSheetState: .hidden,
+            lastOpenedAt: .fixedNow
+        )
+        let peek = SessionViewState(
+            sessionId: .fixedSession,
+            bottomSheetState: .peek,
+            lastOpenedAt: .fixedNow
+        )
+
+        XCTAssertEqual(hidden.resolvedUIState(decisionCount: 0), .browsing)
+        XCTAssertEqual(peek.resolvedUIState(decisionCount: 1), .reviewBrowsing)
+    }
+
+    func test_viewStateEnums_keepStableStoredValues_forLocalRestore() {
+        XCTAssertEqual(BottomSheetState.allCases.map(\.rawValue), [
+            "Hidden",
+            "Peek",
+            "Expanded"
+        ])
+        XCTAssertEqual(SessionUIState.allCases.map(\.rawValue), [
+            "Browsing",
+            "Comparing",
+            "ReviewBrowsing",
+            "ReviewComparing"
+        ])
+    }
+}
+
+private extension UUID {
+    static let fixedSession = UUID(uuidString: "00000000-0000-0000-0000-000000000101")!
+}
+
+private extension Date {
+    static let fixedNow = Date(timeIntervalSince1970: 1_800_000_000)
+}

--- a/Modules/CorePersistence/Project.swift
+++ b/Modules/CorePersistence/Project.swift
@@ -1,0 +1,20 @@
+//
+//  Project.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = ClipyModuleFactory.makeFramework(
+    name: "CorePersistence",
+    bundleIdSuffix: "core-persistence",
+    dependencies: [
+        .project(target: "CoreDomain", path: .relativeToRoot("Modules/CoreDomain"))
+    ],
+    coreDataModels: [
+        .coreDataModel("Resources/ClipyPersistence.xcdatamodeld")
+    ]
+)

--- a/Modules/CorePersistence/Resources/ClipyPersistence.xcdatamodeld/.xccurrentversion
+++ b/Modules/CorePersistence/Resources/ClipyPersistence.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>_XCCurrentVersionName</key>
+    <string>ClipyPersistence.xcdatamodel</string>
+</dict>
+</plist>

--- a/Modules/CorePersistence/Resources/ClipyPersistence.xcdatamodeld/ClipyPersistence.xcdatamodel/contents
+++ b/Modules/CorePersistence/Resources/ClipyPersistence.xcdatamodeld/ClipyPersistence.xcdatamodel/contents
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="CaptureEntity" representedClassName="CaptureEntity" syncable="YES">
+        <attribute name="capturedAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="String"/>
+        <attribute name="imageLocalPath" optional="YES" attributeType="String"/>
+        <attribute name="imageRemoteUrl" attributeType="String"/>
+        <attribute name="itemId" attributeType="String"/>
+        <attribute name="memo" optional="YES" attributeType="String"/>
+        <fetchIndex name="byItemIdIndex">
+            <fetchIndexElement property="itemId" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="DecisionEntity" representedClassName="DecisionEntity" syncable="YES">
+        <attribute name="decidedAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="String"/>
+        <attribute name="itemId" attributeType="String"/>
+        <attribute name="sessionId" attributeType="String"/>
+        <fetchIndex name="bySessionIdIndex">
+            <fetchIndexElement property="sessionId" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="ItemEntity" representedClassName="ItemEntity" syncable="YES">
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="String"/>
+        <attribute name="intentState" attributeType="String"/>
+        <attribute name="note" optional="YES" attributeType="String"/>
+        <attribute name="priceAmount" optional="YES" attributeType="String"/>
+        <attribute name="priceCurrency" optional="YES" attributeType="String"/>
+        <attribute name="priceRawText" optional="YES" attributeType="String"/>
+        <attribute name="productName" optional="YES" attributeType="String"/>
+        <attribute name="sessionId" attributeType="String"/>
+        <attribute name="sourceUrl" attributeType="String"/>
+        <attribute name="thumbnailLocalPath" optional="YES" attributeType="String"/>
+        <attribute name="thumbnailRemoteUrl" optional="YES" attributeType="String"/>
+        <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
+        <fetchIndex name="bySessionIdIndex">
+            <fetchIndexElement property="sessionId" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="SessionEntity" representedClassName="SessionEntity" syncable="YES">
+        <attribute name="abandonedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="closedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="status" attributeType="String"/>
+        <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
+        <fetchIndex name="byIdIndex">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="SessionViewStateEntity" representedClassName="SessionViewStateEntity" syncable="YES">
+        <attribute name="bottomSheetState" attributeType="String"/>
+        <attribute name="lastOpenedAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastWebUrl" optional="YES" attributeType="String"/>
+        <attribute name="sessionId" attributeType="String"/>
+        <fetchIndex name="bySessionIdIndex">
+            <fetchIndexElement property="sessionId" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+</model>

--- a/Modules/CorePersistence/Sources/CoreData/Entities/CaptureEntity.swift
+++ b/Modules/CorePersistence/Sources/CoreData/Entities/CaptureEntity.swift
@@ -1,0 +1,23 @@
+//
+//  CaptureEntity.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import CoreData
+import Foundation
+
+@objc(CaptureEntity)
+final class CaptureEntity: NSManagedObject {
+    @nonobjc class func fetchRequest() -> NSFetchRequest<CaptureEntity> {
+        NSFetchRequest<CaptureEntity>(entityName: "CaptureEntity")
+    }
+
+    @NSManaged var id: String?
+    @NSManaged var itemId: String?
+    @NSManaged var imageRemoteUrl: String?
+    @NSManaged var imageLocalPath: String?
+    @NSManaged var capturedAt: Date?
+    @NSManaged var memo: String?
+}

--- a/Modules/CorePersistence/Sources/CoreData/Entities/DecisionEntity.swift
+++ b/Modules/CorePersistence/Sources/CoreData/Entities/DecisionEntity.swift
@@ -1,0 +1,21 @@
+//
+//  DecisionEntity.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import CoreData
+import Foundation
+
+@objc(DecisionEntity)
+final class DecisionEntity: NSManagedObject {
+    @nonobjc class func fetchRequest() -> NSFetchRequest<DecisionEntity> {
+        NSFetchRequest<DecisionEntity>(entityName: "DecisionEntity")
+    }
+
+    @NSManaged var id: String?
+    @NSManaged var sessionId: String?
+    @NSManaged var itemId: String?
+    @NSManaged var decidedAt: Date?
+}

--- a/Modules/CorePersistence/Sources/CoreData/Entities/ItemEntity.swift
+++ b/Modules/CorePersistence/Sources/CoreData/Entities/ItemEntity.swift
@@ -1,0 +1,30 @@
+//
+//  ItemEntity.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import CoreData
+import Foundation
+
+@objc(ItemEntity)
+final class ItemEntity: NSManagedObject {
+    @nonobjc class func fetchRequest() -> NSFetchRequest<ItemEntity> {
+        NSFetchRequest<ItemEntity>(entityName: "ItemEntity")
+    }
+
+    @NSManaged var id: String?
+    @NSManaged var sessionId: String?
+    @NSManaged var sourceUrl: String?
+    @NSManaged var productName: String?
+    @NSManaged var priceAmount: String?
+    @NSManaged var priceCurrency: String?
+    @NSManaged var priceRawText: String?
+    @NSManaged var thumbnailRemoteUrl: String?
+    @NSManaged var thumbnailLocalPath: String?
+    @NSManaged var note: String?
+    @NSManaged var intentState: String?
+    @NSManaged var createdAt: Date?
+    @NSManaged var updatedAt: Date?
+}

--- a/Modules/CorePersistence/Sources/CoreData/Entities/SessionEntity.swift
+++ b/Modules/CorePersistence/Sources/CoreData/Entities/SessionEntity.swift
@@ -1,0 +1,24 @@
+//
+//  SessionEntity.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import CoreData
+import Foundation
+
+@objc(SessionEntity)
+final class SessionEntity: NSManagedObject {
+    @nonobjc class func fetchRequest() -> NSFetchRequest<SessionEntity> {
+        NSFetchRequest<SessionEntity>(entityName: "SessionEntity")
+    }
+
+    @NSManaged var id: String?
+    @NSManaged var name: String?
+    @NSManaged var status: String?
+    @NSManaged var createdAt: Date?
+    @NSManaged var updatedAt: Date?
+    @NSManaged var closedAt: Date?
+    @NSManaged var abandonedAt: Date?
+}

--- a/Modules/CorePersistence/Sources/CoreData/Entities/SessionViewStateEntity.swift
+++ b/Modules/CorePersistence/Sources/CoreData/Entities/SessionViewStateEntity.swift
@@ -1,0 +1,21 @@
+//
+//  SessionViewStateEntity.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import CoreData
+import Foundation
+
+@objc(SessionViewStateEntity)
+final class SessionViewStateEntity: NSManagedObject {
+    @nonobjc class func fetchRequest() -> NSFetchRequest<SessionViewStateEntity> {
+        NSFetchRequest<SessionViewStateEntity>(entityName: "SessionViewStateEntity")
+    }
+
+    @NSManaged var sessionId: String?
+    @NSManaged var lastWebUrl: String?
+    @NSManaged var bottomSheetState: String?
+    @NSManaged var lastOpenedAt: Date?
+}

--- a/Modules/CorePersistence/Sources/CoreData/Mappers/PersistenceMappingError.swift
+++ b/Modules/CorePersistence/Sources/CoreData/Mappers/PersistenceMappingError.swift
@@ -1,0 +1,31 @@
+//
+//  PersistenceMappingError.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import Foundation
+
+enum PersistenceMappingError: Error, LocalizedError, Equatable {
+    case missingRequiredField(entity: String, field: String)
+    case invalidUUID(field: String, value: String)
+    case invalidEnum(field: String, value: String)
+    case invalidDecimal(field: String, value: String)
+    case incompleteMoneySnapshot(itemId: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingRequiredField(let entity, let field):
+            return "필수 필드가 비어 있습니다: \(entity).\(field)"
+        case .invalidUUID(let field, let value):
+            return "UUID 값이 올바르지 않습니다: \(field)=\(value)"
+        case .invalidEnum(let field, let value):
+            return "enum 값이 올바르지 않습니다: \(field)=\(value)"
+        case .invalidDecimal(let field, let value):
+            return "Decimal 값이 올바르지 않습니다: \(field)=\(value)"
+        case .incompleteMoneySnapshot(let itemId):
+            return "MoneySnapshot 필드가 완전하지 않습니다: itemId=\(itemId)"
+        }
+    }
+}

--- a/Modules/CorePersistence/Sources/CoreData/Mappers/SessionEntityMapper.swift
+++ b/Modules/CorePersistence/Sources/CoreData/Mappers/SessionEntityMapper.swift
@@ -1,0 +1,188 @@
+//
+//  SessionEntityMapper.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import Foundation
+
+import CoreDomain
+
+enum SessionEntityMapper {
+    static func apply(_ session: Session, to entity: SessionEntity) {
+        entity.id = session.id.uuidString
+        entity.name = session.name
+        entity.status = session.status.rawValue
+        entity.createdAt = session.createdAt
+        entity.updatedAt = session.updatedAt
+        entity.closedAt = session.closedAt
+        entity.abandonedAt = session.abandonedAt
+    }
+
+    static func session(
+        from entity: SessionEntity,
+        items: [Item],
+        decisions: [Decision]
+    ) throws -> Session {
+        let id = try uuid(entity.id, field: "SessionEntity.id")
+        let statusText = try required(entity.status, entity: "SessionEntity", field: "status")
+        guard let status = SessionStatus(rawValue: statusText) else {
+            throw PersistenceMappingError.invalidEnum(field: "SessionEntity.status", value: statusText)
+        }
+
+        return Session(
+            id: id,
+            name: entity.name,
+            status: status,
+            createdAt: try required(entity.createdAt, entity: "SessionEntity", field: "createdAt"),
+            updatedAt: try required(entity.updatedAt, entity: "SessionEntity", field: "updatedAt"),
+            closedAt: entity.closedAt,
+            abandonedAt: entity.abandonedAt,
+            items: items,
+            decisions: decisions
+        )
+    }
+
+    static func apply(_ item: Item, to entity: ItemEntity) {
+        entity.id = item.id.uuidString
+        entity.sessionId = item.sessionId.uuidString
+        entity.sourceUrl = item.sourceUrl
+        entity.productName = item.productName
+        entity.priceAmount = item.priceSnapshot.map { NSDecimalNumber(decimal: $0.amount).stringValue }
+        entity.priceCurrency = item.priceSnapshot?.currency
+        entity.priceRawText = item.priceSnapshot?.rawText
+        entity.thumbnailRemoteUrl = item.thumbnailImage?.remoteUrl
+        entity.thumbnailLocalPath = item.thumbnailImage?.localPath
+        entity.note = item.note
+        entity.intentState = item.intentState.rawValue
+        entity.createdAt = item.createdAt
+        entity.updatedAt = item.updatedAt
+    }
+
+    static func item(from entity: ItemEntity, captures: [Capture]) throws -> Item {
+        let id = try uuid(entity.id, field: "ItemEntity.id")
+        let sessionId = try uuid(entity.sessionId, field: "ItemEntity.sessionId")
+        let intentText = try required(entity.intentState, entity: "ItemEntity", field: "intentState")
+        guard let intentState = ItemIntentState(rawValue: intentText) else {
+            throw PersistenceMappingError.invalidEnum(field: "ItemEntity.intentState", value: intentText)
+        }
+
+        return Item(
+            id: id,
+            sessionId: sessionId,
+            sourceUrl: try required(entity.sourceUrl, entity: "ItemEntity", field: "sourceUrl"),
+            productName: entity.productName,
+            priceSnapshot: try moneySnapshot(from: entity),
+            thumbnailImage: thumbnailImage(from: entity),
+            note: entity.note,
+            intentState: intentState,
+            captures: captures,
+            createdAt: try required(entity.createdAt, entity: "ItemEntity", field: "createdAt"),
+            updatedAt: try required(entity.updatedAt, entity: "ItemEntity", field: "updatedAt")
+        )
+    }
+
+    static func apply(_ capture: Capture, to entity: CaptureEntity) {
+        entity.id = capture.id.uuidString
+        entity.itemId = capture.itemId.uuidString
+        entity.imageRemoteUrl = capture.imageRef.remoteUrl
+        entity.imageLocalPath = capture.imageRef.localPath
+        entity.capturedAt = capture.capturedAt
+        entity.memo = capture.memo
+    }
+
+    static func capture(from entity: CaptureEntity) throws -> Capture {
+        Capture(
+            id: try uuid(entity.id, field: "CaptureEntity.id"),
+            itemId: try uuid(entity.itemId, field: "CaptureEntity.itemId"),
+            imageRef: ImageRef(
+                remoteUrl: try required(entity.imageRemoteUrl, entity: "CaptureEntity", field: "imageRemoteUrl"),
+                localPath: entity.imageLocalPath
+            ),
+            capturedAt: try required(entity.capturedAt, entity: "CaptureEntity", field: "capturedAt"),
+            memo: entity.memo
+        )
+    }
+
+    static func apply(_ decision: Decision, to entity: DecisionEntity) {
+        entity.id = decision.id.uuidString
+        entity.sessionId = decision.sessionId.uuidString
+        entity.itemId = decision.itemId.uuidString
+        entity.decidedAt = decision.decidedAt
+    }
+
+    static func decision(from entity: DecisionEntity) throws -> Decision {
+        Decision(
+            id: try uuid(entity.id, field: "DecisionEntity.id"),
+            sessionId: try uuid(entity.sessionId, field: "DecisionEntity.sessionId"),
+            itemId: try uuid(entity.itemId, field: "DecisionEntity.itemId"),
+            decidedAt: try required(entity.decidedAt, entity: "DecisionEntity", field: "decidedAt")
+        )
+    }
+
+    static func apply(_ viewState: SessionViewState, to entity: SessionViewStateEntity) {
+        entity.sessionId = viewState.sessionId.uuidString
+        entity.lastWebUrl = viewState.lastWebUrl
+        entity.bottomSheetState = viewState.bottomSheetState.rawValue
+        entity.lastOpenedAt = viewState.lastOpenedAt
+    }
+
+    static func viewState(from entity: SessionViewStateEntity) throws -> SessionViewState {
+        let stateText = try required(
+            entity.bottomSheetState,
+            entity: "SessionViewStateEntity",
+            field: "bottomSheetState"
+        )
+        guard let bottomSheetState = BottomSheetState(rawValue: stateText) else {
+            throw PersistenceMappingError.invalidEnum(
+                field: "SessionViewStateEntity.bottomSheetState",
+                value: stateText
+            )
+        }
+
+        return SessionViewState(
+            sessionId: try uuid(entity.sessionId, field: "SessionViewStateEntity.sessionId"),
+            lastWebUrl: entity.lastWebUrl,
+            bottomSheetState: bottomSheetState,
+            lastOpenedAt: try required(entity.lastOpenedAt, entity: "SessionViewStateEntity", field: "lastOpenedAt")
+        )
+    }
+
+    private static func moneySnapshot(from entity: ItemEntity) throws -> MoneySnapshot? {
+        switch (entity.priceAmount, entity.priceCurrency) {
+        case (nil, nil):
+            return nil
+        case (let amountText?, let currency?):
+            guard let amount = Decimal(string: amountText) else {
+                throw PersistenceMappingError.invalidDecimal(field: "ItemEntity.priceAmount", value: amountText)
+            }
+            return MoneySnapshot(amount: amount, currency: currency, rawText: entity.priceRawText)
+        default:
+            let itemId = entity.id ?? "<missing>"
+            throw PersistenceMappingError.incompleteMoneySnapshot(itemId: itemId)
+        }
+    }
+
+    private static func thumbnailImage(from entity: ItemEntity) -> ImageRef? {
+        guard let remoteUrl = entity.thumbnailRemoteUrl else { return nil }
+        return ImageRef(remoteUrl: remoteUrl, localPath: entity.thumbnailLocalPath)
+    }
+
+    private static func required<T>(_ value: T?, entity: String, field: String) throws -> T {
+        guard let value else {
+            throw PersistenceMappingError.missingRequiredField(entity: entity, field: field)
+        }
+        return value
+    }
+
+    private static func uuid(_ value: String?, field: String) throws -> UUID {
+        guard let value else {
+            throw PersistenceMappingError.missingRequiredField(entity: field, field: "value")
+        }
+        guard let uuid = UUID(uuidString: value) else {
+            throw PersistenceMappingError.invalidUUID(field: field, value: value)
+        }
+        return uuid
+    }
+}

--- a/Modules/CorePersistence/Sources/CoreData/Stack/ClipyCoreDataError.swift
+++ b/Modules/CorePersistence/Sources/CoreData/Stack/ClipyCoreDataError.swift
@@ -1,0 +1,31 @@
+//
+//  ClipyCoreDataError.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import Foundation
+
+public enum ClipyCoreDataError: Error, LocalizedError {
+    case modelNotFound(String)
+    case modelLoadFailed(URL)
+    case storeLoadFailed(Error)
+    case applicationSupportNotFound
+    case directoryCreationFailed(Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .modelNotFound(let modelName):
+            return "CoreData model을 찾을 수 없습니다: \(modelName)"
+        case .modelLoadFailed(let url):
+            return "CoreData model을 로드할 수 없습니다: \(url.path)"
+        case .storeLoadFailed(let error):
+            return "CoreData store 로딩 실패: \(error.localizedDescription)"
+        case .applicationSupportNotFound:
+            return "Application Support 디렉토리를 찾을 수 없습니다."
+        case .directoryCreationFailed(let error):
+            return "Application Support 디렉토리 생성 실패: \(error.localizedDescription)"
+        }
+    }
+}

--- a/Modules/CorePersistence/Sources/CoreData/Stack/ClipyCoreDataStack.swift
+++ b/Modules/CorePersistence/Sources/CoreData/Stack/ClipyCoreDataStack.swift
@@ -1,0 +1,98 @@
+//
+//  ClipyCoreDataStack.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import CoreData
+import Foundation
+
+public final class ClipyCoreDataStack {
+    private enum Constant {
+        static let modelName = "ClipyPersistence"
+        static let sqliteFileName = "ClipyPersistence.sqlite"
+    }
+
+    private let persistentContainer: NSPersistentContainer
+
+    var viewContext: NSManagedObjectContext {
+        persistentContainer.viewContext
+    }
+
+    public init(storeType: String = NSSQLiteStoreType, storeURL: URL? = nil) throws {
+        let model = try Self.makeManagedObjectModel()
+        let container = NSPersistentContainer(name: Constant.modelName, managedObjectModel: model)
+        let storeDescription = NSPersistentStoreDescription()
+        storeDescription.type = storeType
+        storeDescription.url = try storeURL ?? Self.defaultStoreURL(for: storeType)
+        storeDescription.shouldMigrateStoreAutomatically = true
+        storeDescription.shouldInferMappingModelAutomatically = true
+        container.persistentStoreDescriptions = [storeDescription]
+
+        let loadSemaphore = DispatchSemaphore(value: 0)
+        var loadResult: Result<Void, Error>?
+
+        container.loadPersistentStores { _, error in
+            if let error {
+                loadResult = .failure(error)
+            } else {
+                loadResult = .success(())
+            }
+            loadSemaphore.signal()
+        }
+
+        loadSemaphore.wait()
+
+        if case let .failure(error) = loadResult {
+            throw ClipyCoreDataError.storeLoadFailed(error)
+        }
+
+        container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+        container.viewContext.automaticallyMergesChangesFromParent = true
+        persistentContainer = container
+    }
+
+    func performBackgroundTask<T>(
+        _ block: @escaping (NSManagedObjectContext) throws -> T
+    ) async throws -> T {
+        try await persistentContainer.performBackgroundTask { context in
+            context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+            return try block(context)
+        }
+    }
+
+    private static func makeManagedObjectModel() throws -> NSManagedObjectModel {
+        let bundle = Bundle(for: ClipyCoreDataStack.self)
+        let modelURL = bundle.url(forResource: Constant.modelName, withExtension: "momd")
+            ?? bundle.url(forResource: Constant.modelName, withExtension: "mom")
+
+        guard let modelURL else {
+            throw ClipyCoreDataError.modelNotFound(Constant.modelName)
+        }
+
+        guard let model = NSManagedObjectModel(contentsOf: modelURL) else {
+            throw ClipyCoreDataError.modelLoadFailed(modelURL)
+        }
+
+        return model
+    }
+
+    private static func defaultStoreURL(for storeType: String) throws -> URL {
+        if storeType == NSInMemoryStoreType {
+            return URL(fileURLWithPath: "/dev/null")
+        }
+
+        guard let baseURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            throw ClipyCoreDataError.applicationSupportNotFound
+        }
+
+        do {
+            try FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: true)
+        } catch {
+            throw ClipyCoreDataError.directoryCreationFailed(error)
+        }
+
+        return baseURL.appendingPathComponent(Constant.sqliteFileName)
+    }
+}

--- a/Modules/CorePersistence/Sources/Stores/CoreDataSessionRepository.swift
+++ b/Modules/CorePersistence/Sources/Stores/CoreDataSessionRepository.swift
@@ -1,0 +1,26 @@
+//
+//  CoreDataSessionRepository.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import Foundation
+
+import CoreDomain
+
+public final class CoreDataSessionRepository: SessionRepository {
+    private let store: SessionCoreDataStore
+
+    public init(stack: ClipyCoreDataStack) {
+        store = SessionCoreDataStore(stack: stack)
+    }
+
+    public func save(_ snapshot: SessionSnapshot) async throws {
+        try await store.save(snapshot)
+    }
+
+    public func loadSession(id: UUID) async throws -> SessionSnapshot? {
+        try await store.loadSession(id: id)
+    }
+}

--- a/Modules/CorePersistence/Sources/Stores/SessionCoreDataStore.swift
+++ b/Modules/CorePersistence/Sources/Stores/SessionCoreDataStore.swift
@@ -1,0 +1,207 @@
+//
+//  SessionCoreDataStore.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import CoreData
+import Foundation
+
+import CoreDomain
+
+final class SessionCoreDataStore {
+    private let stack: ClipyCoreDataStack
+
+    init(stack: ClipyCoreDataStack) {
+        self.stack = stack
+    }
+
+    func save(_ snapshot: SessionSnapshot) async throws {
+        try await stack.performBackgroundTask { context in
+            try Self.save(snapshot, in: context)
+        }
+    }
+
+    func loadSession(id: UUID) async throws -> SessionSnapshot? {
+        let context = stack.viewContext
+
+        return try await context.perform {
+            try Self.loadSession(id: id, in: context)
+        }
+    }
+}
+
+private extension SessionCoreDataStore {
+    static func save(_ snapshot: SessionSnapshot, in context: NSManagedObjectContext) throws {
+        let session = snapshot.session
+        let sessionEntity = try fetchOrCreateSessionEntity(
+            id: session.id.uuidString,
+            in: context
+        )
+        SessionEntityMapper.apply(session, to: sessionEntity)
+
+        try replaceChildEntities(for: session, in: context)
+
+        if let viewState = snapshot.viewState {
+            let viewStateEntity = try fetchOrCreateViewStateEntity(
+                sessionId: viewState.sessionId.uuidString,
+                in: context
+            )
+            SessionEntityMapper.apply(viewState, to: viewStateEntity)
+        } else {
+            try deleteViewState(sessionId: session.id.uuidString, in: context)
+        }
+
+        try context.save()
+    }
+
+    static func loadSession(id: UUID, in context: NSManagedObjectContext) throws -> SessionSnapshot? {
+        guard let sessionEntity = try fetchSessionEntity(id: id.uuidString, in: context) else {
+            return nil
+        }
+
+        let itemEntities = try fetchItemEntities(sessionId: id.uuidString, in: context)
+        let capturesByItemId = try fetchCapturesByItemId(
+            itemIds: itemEntities.compactMap(\.id),
+            in: context
+        )
+        let items = try itemEntities.map { entity in
+            try SessionEntityMapper.item(
+                from: entity,
+                captures: capturesByItemId[entity.id ?? "", default: []]
+            )
+        }
+        let decisions = try fetchDecisionEntities(sessionId: id.uuidString, in: context)
+            .map { try SessionEntityMapper.decision(from: $0) }
+        let session = try SessionEntityMapper.session(
+            from: sessionEntity,
+            items: items,
+            decisions: decisions
+        )
+        let viewState = try fetchViewStateEntity(sessionId: id.uuidString, in: context)
+            .map { try SessionEntityMapper.viewState(from: $0) }
+
+        return SessionSnapshot(session: session, viewState: viewState)
+    }
+
+    static func replaceChildEntities(for session: Session, in context: NSManagedObjectContext) throws {
+        let sessionId = session.id.uuidString
+        let existingItemIds = try fetchItemEntities(sessionId: sessionId, in: context).compactMap(\.id)
+        try deleteCaptures(itemIds: existingItemIds, in: context)
+        try deleteItems(sessionId: sessionId, in: context)
+        try deleteDecisions(sessionId: sessionId, in: context)
+
+        for item in session.items {
+            let itemEntity = ItemEntity(context: context)
+            SessionEntityMapper.apply(item, to: itemEntity)
+
+            for capture in item.captures {
+                let captureEntity = CaptureEntity(context: context)
+                SessionEntityMapper.apply(capture, to: captureEntity)
+            }
+        }
+
+        for decision in session.decisions {
+            let decisionEntity = DecisionEntity(context: context)
+            SessionEntityMapper.apply(decision, to: decisionEntity)
+        }
+    }
+
+    static func fetchOrCreateSessionEntity(id: String, in context: NSManagedObjectContext) throws -> SessionEntity {
+        if let entity = try fetchSessionEntity(id: id, in: context) {
+            return entity
+        }
+        return SessionEntity(context: context)
+    }
+
+    static func fetchSessionEntity(id: String, in context: NSManagedObjectContext) throws -> SessionEntity? {
+        let request = SessionEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", id)
+        request.fetchLimit = 1
+        return try context.fetch(request).first
+    }
+
+    static func fetchOrCreateViewStateEntity(
+        sessionId: String,
+        in context: NSManagedObjectContext
+    ) throws -> SessionViewStateEntity {
+        if let entity = try fetchViewStateEntity(sessionId: sessionId, in: context) {
+            return entity
+        }
+        return SessionViewStateEntity(context: context)
+    }
+
+    static func fetchViewStateEntity(
+        sessionId: String,
+        in context: NSManagedObjectContext
+    ) throws -> SessionViewStateEntity? {
+        let request = SessionViewStateEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "sessionId == %@", sessionId)
+        request.fetchLimit = 1
+        return try context.fetch(request).first
+    }
+
+    static func fetchItemEntities(sessionId: String, in context: NSManagedObjectContext) throws -> [ItemEntity] {
+        let request = ItemEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "sessionId == %@", sessionId)
+        request.sortDescriptors = [
+            NSSortDescriptor(key: "createdAt", ascending: true),
+            NSSortDescriptor(key: "id", ascending: true)
+        ]
+        return try context.fetch(request)
+    }
+
+    static func fetchCapturesByItemId(
+        itemIds: [String],
+        in context: NSManagedObjectContext
+    ) throws -> [String: [Capture]] {
+        guard !itemIds.isEmpty else { return [:] }
+
+        let request = CaptureEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "itemId IN %@", itemIds)
+        request.sortDescriptors = [
+            NSSortDescriptor(key: "capturedAt", ascending: true),
+            NSSortDescriptor(key: "id", ascending: true)
+        ]
+
+        let captures = try context.fetch(request).map { try SessionEntityMapper.capture(from: $0) }
+        return Dictionary(grouping: captures, by: { $0.itemId.uuidString })
+    }
+
+    static func fetchDecisionEntities(sessionId: String, in context: NSManagedObjectContext) throws -> [DecisionEntity] {
+        let request = DecisionEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "sessionId == %@", sessionId)
+        request.sortDescriptors = [
+            NSSortDescriptor(key: "decidedAt", ascending: true),
+            NSSortDescriptor(key: "id", ascending: true)
+        ]
+        return try context.fetch(request)
+    }
+
+    static func deleteItems(sessionId: String, in context: NSManagedObjectContext) throws {
+        let request = ItemEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "sessionId == %@", sessionId)
+        try context.fetch(request).forEach(context.delete)
+    }
+
+    static func deleteCaptures(itemIds: [String], in context: NSManagedObjectContext) throws {
+        guard !itemIds.isEmpty else { return }
+
+        let request = CaptureEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "itemId IN %@", itemIds)
+        try context.fetch(request).forEach(context.delete)
+    }
+
+    static func deleteDecisions(sessionId: String, in context: NSManagedObjectContext) throws {
+        let request = DecisionEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "sessionId == %@", sessionId)
+        try context.fetch(request).forEach(context.delete)
+    }
+
+    static func deleteViewState(sessionId: String, in context: NSManagedObjectContext) throws {
+        if let entity = try fetchViewStateEntity(sessionId: sessionId, in: context) {
+            context.delete(entity)
+        }
+    }
+}

--- a/Modules/CorePersistence/Tests/SessionRepositoryTests.swift
+++ b/Modules/CorePersistence/Tests/SessionRepositoryTests.swift
@@ -1,0 +1,190 @@
+//
+//  SessionRepositoryTests.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/5/26.
+//
+
+import CoreData
+import XCTest
+
+import CoreDomain
+import CorePersistence
+
+final class SessionRepositoryTests: XCTestCase {
+    private var stack: ClipyCoreDataStack!
+    private var sut: CoreDataSessionRepository!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        stack = try ClipyCoreDataStack(storeType: NSInMemoryStoreType)
+        sut = CoreDataSessionRepository(stack: stack)
+    }
+
+    override func tearDown() {
+        sut = nil
+        stack = nil
+        super.tearDown()
+    }
+
+    @MainActor
+    func test_savedSession_restoresDomainAndViewState_forLocalReentry() async throws {
+        let snapshot = makeDecidedSnapshot()
+
+        try await sut.save(snapshot)
+        let loaded = try await sut.loadSession(id: snapshot.session.id)
+
+        XCTAssertEqual(loaded, snapshot)
+        XCTAssertEqual(
+            loaded?.viewState?.resolvedUIState(decisionCount: loaded?.session.decisions.count ?? 0),
+            .reviewComparing
+        )
+    }
+
+    @MainActor
+    func test_savingSameSession_replacesItemsAndViewState_withoutStaleRows() async throws {
+        let first = makePendingSnapshot(
+            itemId: UUID(uuidString: "00000000-0000-0000-0000-000000000202")!,
+            sourceUrl: "https://example.com/first",
+            lastWebUrl: "https://example.com/first",
+            bottomSheetState: .peek
+        )
+        let second = makePendingSnapshot(
+            itemId: UUID(uuidString: "00000000-0000-0000-0000-000000000203")!,
+            sourceUrl: "https://example.com/second",
+            lastWebUrl: "https://example.com/second",
+            bottomSheetState: .expanded
+        )
+
+        try await sut.save(first)
+        try await sut.save(second)
+        let loaded = try await sut.loadSession(id: second.session.id)
+
+        XCTAssertEqual(loaded?.session.items.map(\.sourceUrl), ["https://example.com/second"])
+        XCTAssertEqual(loaded?.viewState?.lastWebUrl, "https://example.com/second")
+        XCTAssertEqual(loaded?.viewState?.bottomSheetState, .expanded)
+    }
+
+    @MainActor
+    func test_savedSession_preservesOptionalItemValues_forLocalRestore() async throws {
+        let item = makeItem(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000204")!,
+            priceSnapshot: MoneySnapshot(amount: Decimal(string: "1299.99")!, currency: "USD", rawText: "$1,299.99"),
+            thumbnailImage: ImageRef(
+                remoteUrl: "https://example.com/images/thumb.png",
+                localPath: "cache/thumb.png"
+            )
+        )
+        let session = Session(
+            id: .fixedSession,
+            name: "Travel bag",
+            status: .collecting,
+            createdAt: .created,
+            updatedAt: .updated,
+            items: [item]
+        )
+
+        try await sut.save(SessionSnapshot(session: session))
+        let loadedItem = try await sut.loadSession(id: session.id)?.session.items.first
+
+        XCTAssertEqual(loadedItem?.priceSnapshot, item.priceSnapshot)
+        XCTAssertEqual(loadedItem?.thumbnailImage, item.thumbnailImage)
+        XCTAssertEqual(loadedItem?.note, item.note)
+    }
+
+    private func makeDecidedSnapshot() -> SessionSnapshot {
+        let item = makeItem(id: .fixedItem)
+        let decision = Decision(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000205")!,
+            sessionId: .fixedSession,
+            itemId: item.id,
+            decidedAt: .decided
+        )
+        let session = Session(
+            id: .fixedSession,
+            name: "Travel bag",
+            status: .decided,
+            createdAt: .created,
+            updatedAt: .updated,
+            items: [item],
+            decisions: [decision]
+        )
+        let viewState = SessionViewState(
+            sessionId: session.id,
+            lastWebUrl: item.sourceUrl,
+            bottomSheetState: .expanded,
+            lastOpenedAt: .opened
+        )
+
+        return SessionSnapshot(session: session, viewState: viewState)
+    }
+
+    private func makePendingSnapshot(
+        itemId: UUID,
+        sourceUrl: String,
+        lastWebUrl: String,
+        bottomSheetState: BottomSheetState
+    ) -> SessionSnapshot {
+        let item = makeItem(id: itemId, sourceUrl: sourceUrl)
+        let session = Session(
+            id: .fixedSession,
+            name: "Travel bag",
+            status: .pending,
+            createdAt: .created,
+            updatedAt: .updated,
+            closedAt: .closed,
+            items: [item]
+        )
+        let viewState = SessionViewState(
+            sessionId: session.id,
+            lastWebUrl: lastWebUrl,
+            bottomSheetState: bottomSheetState,
+            lastOpenedAt: .opened
+        )
+
+        return SessionSnapshot(session: session, viewState: viewState)
+    }
+
+    private func makeItem(
+        id: UUID,
+        sourceUrl: String = "https://example.com/products/clipy-case",
+        priceSnapshot: MoneySnapshot? = nil,
+        thumbnailImage: ImageRef? = nil
+    ) -> Item {
+        let capture = Capture(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000206")!,
+            itemId: id,
+            imageRef: ImageRef(remoteUrl: "https://example.com/images/capture.png"),
+            capturedAt: .captured,
+            memo: "front view"
+        )
+
+        return Item(
+            id: id,
+            sessionId: .fixedSession,
+            sourceUrl: sourceUrl,
+            productName: "Clipy Case",
+            priceSnapshot: priceSnapshot,
+            thumbnailImage: thumbnailImage,
+            note: "Lightweight option",
+            intentState: .interested,
+            captures: [capture],
+            createdAt: .created,
+            updatedAt: .updated
+        )
+    }
+}
+
+private extension UUID {
+    static let fixedSession = UUID(uuidString: "00000000-0000-0000-0000-000000000201")!
+    static let fixedItem = UUID(uuidString: "00000000-0000-0000-0000-000000000202")!
+}
+
+private extension Date {
+    static let created = Date(timeIntervalSince1970: 1_800_000_000)
+    static let updated = Date(timeIntervalSince1970: 1_800_000_100)
+    static let closed = Date(timeIntervalSince1970: 1_800_000_200)
+    static let captured = Date(timeIntervalSince1970: 1_800_000_300)
+    static let decided = Date(timeIntervalSince1970: 1_800_000_400)
+    static let opened = Date(timeIntervalSince1970: 1_800_000_500)
+}

--- a/Tuist/ProjectDescriptionHelpers/ClipyModuleFactory.swift
+++ b/Tuist/ProjectDescriptionHelpers/ClipyModuleFactory.swift
@@ -54,7 +54,8 @@ public enum ClipyModuleFactory {
         name: String,
         bundleIdSuffix: String,
         dependencies: [TargetDependency] = [],
-        hasTests: Bool = true
+        hasTests: Bool = true,
+        coreDataModels: [CoreDataModel] = []
     ) -> Project {
         var targets: [Target] = [
             .target(
@@ -65,7 +66,8 @@ public enum ClipyModuleFactory {
                 deploymentTargets: ClipyProjectConfig.deploymentTargets,
                 infoPlist: .default,
                 sources: ["\(ClipyProjectConfig.sourcesDirectory)/**"],
-                dependencies: dependencies
+                dependencies: dependencies,
+                coreDataModels: coreDataModels
             )
         ]
 

--- a/Tuist/ProjectDescriptionHelpers/ClipyModuleFactory.swift
+++ b/Tuist/ProjectDescriptionHelpers/ClipyModuleFactory.swift
@@ -11,6 +11,7 @@ public enum ClipyModuleFactory {
     public static func makeApp(
         name: String,
         bundleIdSuffix: String,
+        dependencies: [TargetDependency] = [],
         hasTests: Bool = true
     ) -> Project {
         var targets: [Target] = [
@@ -22,7 +23,7 @@ public enum ClipyModuleFactory {
                 deploymentTargets: ClipyProjectConfig.deploymentTargets,
                 infoPlist: .extendingDefault(with: ClipyProjectConfig.baseInfoPlist),
                 sources: ["\(ClipyProjectConfig.sourcesDirectory)/**"],
-                dependencies: []
+                dependencies: dependencies
             )
         ]
 

--- a/Workspace.swift
+++ b/Workspace.swift
@@ -10,7 +10,6 @@ import ProjectDescription
 let workspace = Workspace(
     name: "Clipy",
     projects: [
-        "Modules/AppMain",
-        "Modules/CoreDomain"
+        "Modules/AppMain"
     ]
 )


### PR DESCRIPTION
  ## 무엇을 바꿨나요?

  Session 저장 흐름을 CoreDomain과 CorePersistence 구현으로 연결했습니다.

  - CoreDomain에 `SessionViewState`, `SessionSnapshot`, `SessionRepository`를 추가했습니다.
  - CorePersistence module을 추가하고 CoreData model, entity, mapper, stack, store, repository를 구성했습니다.
  - AppMain은 CorePersistence에만 의존하고, CorePersistence가 CoreDomain을 바라보는 방향으로 module 의존을 정리했습니다.
  - Session 저장/복원 규칙을 설명하는 테스트를 추가했습니다.

  ## 왜 바꿨나요?

  Clipy의 session은 사용자가 다시 들어왔을 때 이어서 볼 수 있어야 하는 browsing 상태와 bottom sheet 상태를 함께 다룹니다.
  그래서 저장 구조를 DB schema만 따로 두기보다 - 앱에서 다루는 session snapshot 단위로 저장하고 복원할 수 있게 Domain CoreData 구현을 한 PR 안에 담았습니다.

  ## 변경 범위

  - AppMain 중심 workspace / module 의존 정리
  - CoreDomain session 저장 계약 추가
  - CorePersistence module 추가
  - CoreData model resource 추가
  - CoreData entity / mapper / stack / store / repository 구현
  - Session repository 저장/복원 테스트 추가
  - 공개 문서의 module 구조와 setup 설명 갱신

  ## 제외한 범위

  - CoreData migration 정책
  - CoreData relationship / constraint 고도화
  - platform_cases 구조 추가 반영
  - lint convention 일괄 적용
  - UI 화면 연결
  - DI container 분리

  ## 확인한 내용

  - [x] `mise exec -- tuist generate`
  - [x] `./scripts/validate_ios_baseline.sh` 또는 필요한 경우 `CLIPY_IOS_VALIDATION_MODE=test ./scripts/validate_ios_baseline.sh` 확인
  - [x] 생성된 `.xcodeproj`, `.xcworkspace`, `Derived/` 미포함 확인

  ## 테스트와 문서
  - 저장한 session snapshot을 다시 복원하는지 확인
  - 같은 session을 다시 저장할 때 이전 row가 stale 상태로 남지 않는지 확인
  - optional item value가 저장/복원 과정에서 유지되는지 확인
  - bottom sheet 상태가 session UI state로 해석되는 규칙 확인

  문서는 공개 가능한 범위에서 `Docs/Open/PROJECT_STRUCTURE.md`, `Docs/Open/SETUP.md`를 갱신했습니다.

  ## 관련 이슈

  Closes #10

  Related: CLIPY-59, CLIPY-60
