### PR TITLE
[CLIPY-42] Session shell과 WebView wrapper 작성

### DIFF
--- a/Docs/Open/PROJECT_STRUCTURE.md
+++ b/Docs/Open/PROJECT_STRUCTURE.md
@@ -16,6 +16,14 @@ Clipy-iOS/
       Project.swift
       Sources/
       Tests/
+    FeatureSession/
+      Project.swift
+      Sources/
+        Interface/
+        SessionView/
+        SessionWeb/
+      Tests/
+        SessionView/
     CoreDomain/
       Project.swift
       Sources/
@@ -32,12 +40,21 @@ Clipy-iOS/
 | Module | 책임 |
 | --- | --- |
 | `AppMain` | app entry point, scene lifecycle, app 조립 |
+| `FeatureSession` | Session 화면 진입, UIKit shell, WebView wrapper |
 | `CoreDomain` | Session, Item, Decision, Capture, SessionSnapshot와 repository contract |
 | `CorePersistence` | CoreData 기반 local 저장 구조, entity mapping, repository 구현 |
 
 module이 늘어나도 기본 구조는 같습니다.
-각 module은 자기 `Project.swift`, `Sources/`, `Tests/`를 가집니다.
+각 module은 자기 `Project.swift`와 `Sources/`를 가집니다.
+`Tests/`는 오래 남길 테스트가 생길 때 추가합니다.
 파일이 생기기 전의 빈 directory는 유지하지 않습니다.
+
+Feature module 내부는 public entry와 제품 기능 surface를 기준으로 나눕니다.
+`Interface/`에는 다른 module이 아는 진입 API를 둡니다.
+나머지는 `SessionView/`, `SessionWeb/`처럼 feature 내부 기능 단위로 둡니다.
+
+세부 ViewController / ViewModel 작성 기준은 팀 내부 규칙에서 관리합니다.
+공개 문서에서는 module 구조와 의존 방향만 설명합니다.
 
 ## Module 확장 기준
 
@@ -49,7 +66,7 @@ Module은 화면 수가 아니라 책임 경계를 기준으로 늘립니다.
 - 실제 구현 작업에서 책임이 필요합니다.
 - module 책임을 한 문장으로 설명할 수 있습니다.
 - 의존 방향이 기존 구조와 어긋나지 않습니다.
-- `Project.swift`, scheme, test target, 검증 방법을 함께 정할 수 있습니다.
+- `Project.swift`, scheme, 테스트 필요 여부, 검증 방법을 함께 정할 수 있습니다.
 - 다음 작업 범위의 구현을 미리 당겨오지 않습니다.
 
 ## 의존 방향
@@ -57,10 +74,12 @@ Module은 화면 수가 아니라 책임 경계를 기준으로 늘립니다.
 현재 module 의존은 아래처럼 둡니다.
 
 ```plaintext
+AppMain -> FeatureSession -> CoreDomain
 AppMain -> CorePersistence -> CoreDomain
 ```
 
 `AppMain`은 app entry point와 composition root를 맡습니다.
+`FeatureSession`은 Session 화면과 WebView wrapper를 맡습니다.
 `CorePersistence`는 `CoreDomain`의 repository contract를 CoreData로 구현합니다.
 `CoreDomain`은 저장소 구현, WebView, UIKit detail을 모릅니다.
 
@@ -132,14 +151,14 @@ Home은 세션 진입과 관리에 집중합니다.
 탐색, 수집, 비교, 결정, 리뷰는 대부분 Session 안에서 처리합니다.
 
 그래서 module은 아래 방향으로 확장될 수 있습니다.
-실제 target은 해당 책임을 가진 구현 작업이 열릴 때 만듭니다.
+실제 target은 해당 책임을 가진 구현 작업이 열릴 때 만듭니다. `FeatureSession`은 Session shell과 WebView wrapper 책임이 필요해지면서 추가했습니다.
 
 | 책임 | 예시 module |
 | --- | --- |
 | WebView, URL validation, web primitive | `CoreWeb` |
 | 공용 UIKit style/component | `CoreUI` |
 | Home, session list, start/reopen entry flow | `FeatureHome` |
-| Session screen, WebView surface, bottom sheet, Decision surface | `FeatureSession` |
+| Session screen, bottom sheet, Decision surface | `FeatureSession` |
 
 `Decision Screen`과 `Overlay Editor`는 초기 기준에서 Session 내부 surface로 봅니다.
 별도 app-level feature module로 먼저 분리하지 않습니다.

--- a/Modules/AppMain/Project.swift
+++ b/Modules/AppMain/Project.swift
@@ -12,6 +12,7 @@ let project = ClipyModuleFactory.makeApp(
     name: "AppMain",
     bundleIdSuffix: "app",
     dependencies: [
+        .project(target: "FeatureSession", path: .relativeToRoot("Modules/FeatureSession")),
         .project(target: "CorePersistence", path: .relativeToRoot("Modules/CorePersistence"))
     ]
 )

--- a/Modules/AppMain/Sources/ClipyRootViewController.swift
+++ b/Modules/AppMain/Sources/ClipyRootViewController.swift
@@ -7,7 +7,12 @@
 
 import UIKit
 
+import FeatureSession
+
 final class ClipyRootViewController: UIViewController {
+    private let sampleSessionId = UUID()
+    private let sessionSmokeURL = URL(string: "https://www.google.com")
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -24,7 +29,12 @@ final class ClipyRootViewController: UIViewController {
         subtitleLabel.textColor = .secondaryLabel
         subtitleLabel.textAlignment = .center
 
-        let stackView = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
+        let openSessionButton = UIButton(type: .system)
+        openSessionButton.setTitle("Open Session", for: .normal)
+        openSessionButton.titleLabel?.font = .preferredFont(forTextStyle: .headline)
+        openSessionButton.addTarget(self, action: #selector(openSession), for: .touchUpInside)
+
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel, openSessionButton])
         stackView.axis = .vertical
         stackView.alignment = .center
         stackView.spacing = 12
@@ -38,5 +48,15 @@ final class ClipyRootViewController: UIViewController {
             stackView.leadingAnchor.constraint(greaterThanOrEqualTo: view.layoutMarginsGuide.leadingAnchor),
             stackView.trailingAnchor.constraint(lessThanOrEqualTo: view.layoutMarginsGuide.trailingAnchor)
         ])
+    }
+
+    @objc private func openSession() {
+        let context = SessionLaunchContext(
+            sessionId: sampleSessionId,
+            initialURL: sessionSmokeURL
+        )
+        let viewController = SessionFeature.makeViewController(context: context)
+
+        navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/Modules/AppMain/Sources/ClipyRootViewController.swift
+++ b/Modules/AppMain/Sources/ClipyRootViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import FeatureSession
 
+/// Home 구현 전까지 세션 진입 smoke를 맡는 root 화면입니다.
 final class ClipyRootViewController: UIViewController {
     private let sampleSessionId = UUID()
     private let sessionSmokeURL = URL(string: "https://www.google.com")

--- a/Modules/AppMain/Sources/SceneDelegate.swift
+++ b/Modules/AppMain/Sources/SceneDelegate.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+/// 앱 window를 만들고 현재 root navigation 흐름을 시작합니다.
 final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
 

--- a/Modules/AppMain/Sources/SceneDelegate.swift
+++ b/Modules/AppMain/Sources/SceneDelegate.swift
@@ -20,7 +20,9 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
 
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = ClipyRootViewController()
+        let navigationController = UINavigationController(rootViewController: ClipyRootViewController())
+        navigationController.setNavigationBarHidden(true, animated: false)
+        window.rootViewController = navigationController
         window.makeKeyAndVisible()
         self.window = window
     }

--- a/Modules/FeatureSession/Project.swift
+++ b/Modules/FeatureSession/Project.swift
@@ -1,0 +1,21 @@
+//
+//  Project.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/9/26.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = ClipyModuleFactory.makeFramework(
+    name: "FeatureSession",
+    bundleIdSuffix: "feature-session",
+    dependencies: [
+        .external(name: "RxSwift"),
+        .external(name: "RxCocoa"),
+        .external(name: "RxRelay"),
+        .project(target: "CoreDomain", path: .relativeToRoot("Modules/CoreDomain"))
+    ],
+    hasTests: true
+)

--- a/Modules/FeatureSession/Sources/Interface/SessionFeature.swift
+++ b/Modules/FeatureSession/Sources/Interface/SessionFeature.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+/// AppMain이 Session 화면을 열 때 사용하는 FeatureSession의 공개 진입점입니다.
 public enum SessionFeature {
     public static func makeViewController(
         context: SessionLaunchContext

--- a/Modules/FeatureSession/Sources/Interface/SessionFeature.swift
+++ b/Modules/FeatureSession/Sources/Interface/SessionFeature.swift
@@ -1,0 +1,16 @@
+//
+//  SessionFeature.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/9/26.
+//
+
+import UIKit
+
+public enum SessionFeature {
+    public static func makeViewController(
+        context: SessionLaunchContext
+    ) -> UIViewController {
+        SessionViewController(viewModel: SessionViewModel(context: context))
+    }
+}

--- a/Modules/FeatureSession/Sources/Interface/SessionLaunchContext.swift
+++ b/Modules/FeatureSession/Sources/Interface/SessionLaunchContext.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// Session 화면을 열 때 이미 결정된 session id와 초기 URL을 전달합니다.
 public struct SessionLaunchContext: Equatable {
     public let sessionId: UUID
     public let initialURL: URL?

--- a/Modules/FeatureSession/Sources/Interface/SessionLaunchContext.swift
+++ b/Modules/FeatureSession/Sources/Interface/SessionLaunchContext.swift
@@ -1,0 +1,18 @@
+//
+//  SessionLaunchContext.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/9/26.
+//
+
+import Foundation
+
+public struct SessionLaunchContext: Equatable {
+    public let sessionId: UUID
+    public let initialURL: URL?
+
+    public init(sessionId: UUID, initialURL: URL? = nil) {
+        self.sessionId = sessionId
+        self.initialURL = initialURL
+    }
+}

--- a/Modules/FeatureSession/Sources/SessionView/SessionView.swift
+++ b/Modules/FeatureSession/Sources/SessionView/SessionView.swift
@@ -11,6 +11,7 @@ import UIKit
 import RxCocoa
 import RxSwift
 
+/// Session 화면의 header와 browser 영역을 배치하는 root view입니다.
 final class SessionView: UIView {
     fileprivate let homeButton = UIButton(type: .system)
     private let browserView = SessionWebView()

--- a/Modules/FeatureSession/Sources/SessionView/SessionView.swift
+++ b/Modules/FeatureSession/Sources/SessionView/SessionView.swift
@@ -1,0 +1,94 @@
+//
+//  SessionView.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/9/26.
+//
+
+import Foundation
+import UIKit
+
+import RxCocoa
+import RxSwift
+
+final class SessionView: UIView {
+    fileprivate let homeButton = UIButton(type: .system)
+    private let browserView = SessionWebView()
+    private let headerView = UIView()
+    private let titleLabel = UILabel()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureHierarchy()
+        configureStyle()
+        configureLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    private func configureHierarchy() {
+        addSubview(headerView)
+        addSubview(browserView)
+
+        headerView.addSubview(homeButton)
+        headerView.addSubview(titleLabel)
+    }
+
+    private func configureStyle() {
+        backgroundColor = .systemBackground
+        headerView.backgroundColor = .systemBackground
+
+        homeButton.setTitle("Home", for: .normal)
+        homeButton.titleLabel?.font = .preferredFont(forTextStyle: .headline)
+
+        titleLabel.text = "Session"
+        titleLabel.font = .preferredFont(forTextStyle: .headline)
+        titleLabel.textAlignment = .center
+    }
+
+    private func configureLayout() {
+        headerView.translatesAutoresizingMaskIntoConstraints = false
+        browserView.translatesAutoresizingMaskIntoConstraints = false
+        homeButton.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            headerView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            headerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            headerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            headerView.heightAnchor.constraint(equalToConstant: 56),
+
+            browserView.topAnchor.constraint(equalTo: headerView.bottomAnchor),
+            browserView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            browserView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            browserView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            homeButton.leadingAnchor.constraint(equalTo: headerView.layoutMarginsGuide.leadingAnchor),
+            homeButton.centerYAnchor.constraint(equalTo: headerView.centerYAnchor),
+
+            titleLabel.centerXAnchor.constraint(equalTo: headerView.centerXAnchor),
+            titleLabel.centerYAnchor.constraint(equalTo: headerView.centerYAnchor),
+            titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: homeButton.trailingAnchor, constant: 12),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: headerView.layoutMarginsGuide.trailingAnchor)
+        ])
+    }
+}
+
+// MARK: - Interface
+
+extension SessionView {
+    func load(url: URL) {
+        browserView.load(url: url)
+    }
+}
+
+// MARK: - Reactive
+
+extension Reactive where Base: SessionView {
+    var homeTap: ControlEvent<Void> {
+        base.homeButton.rx.tap
+    }
+}

--- a/Modules/FeatureSession/Sources/SessionView/SessionViewController.swift
+++ b/Modules/FeatureSession/Sources/SessionView/SessionViewController.swift
@@ -1,0 +1,79 @@
+//
+//  SessionViewController.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/9/26.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+
+final class SessionViewController: UIViewController {
+    private let rootView = SessionView()
+    private let viewModel: SessionViewModel
+    private let disposeBag = DisposeBag()
+    private var previousPopGestureEnabled: Bool?
+
+    init(viewModel: SessionViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override func loadView() {
+        view = rootView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        bindViewModel()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationItem.hidesBackButton = true
+        previousPopGestureEnabled = navigationController?.interactivePopGestureRecognizer?.isEnabled
+        navigationController?.interactivePopGestureRecognizer?.isEnabled = false
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        if let previousPopGestureEnabled {
+            navigationController?.interactivePopGestureRecognizer?.isEnabled = previousPopGestureEnabled
+        }
+        super.viewWillDisappear(animated)
+    }
+
+    private func bindViewModel() {
+        let output = viewModel.transform(
+            input: SessionViewModel.Input(
+                viewDidLoad: .just(()),
+                homeTap: rootView.rx.homeTap.asSignal()
+            )
+        )
+
+        output.initialLoadURL
+            .emit(with: self) { owner, url in
+                owner.rootView.load(url: url)
+            }
+            .disposed(by: disposeBag)
+
+        output.route
+            .emit(with: self) { owner, route in
+                owner.handle(route: route)
+            }
+            .disposed(by: disposeBag)
+    }
+
+    private func handle(route: SessionRoute) {
+        switch route {
+        case .home:
+            navigationController?.popViewController(animated: true)
+        }
+    }
+}

--- a/Modules/FeatureSession/Sources/SessionView/SessionViewController.swift
+++ b/Modules/FeatureSession/Sources/SessionView/SessionViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 import RxCocoa
 import RxSwift
 
+/// Session 화면의 lifecycle, binding, Home route 처리를 맡는 UIKit shell입니다.
 final class SessionViewController: UIViewController {
     private let rootView = SessionView()
     private let viewModel: SessionViewModel

--- a/Modules/FeatureSession/Sources/SessionView/SessionViewModel.swift
+++ b/Modules/FeatureSession/Sources/SessionView/SessionViewModel.swift
@@ -1,0 +1,46 @@
+//
+//  SessionViewModel.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/9/26.
+//
+
+import Foundation
+import RxCocoa
+
+enum SessionRoute: Equatable {
+    case home
+}
+
+final class SessionViewModel {
+    struct Input {
+        let viewDidLoad: Signal<Void>
+        let homeTap: Signal<Void>
+    }
+
+    struct Output {
+        let initialLoadURL: Signal<URL>
+        let route: Signal<SessionRoute>
+    }
+
+    private let context: SessionLaunchContext
+
+    init(context: SessionLaunchContext) {
+        self.context = context
+    }
+
+    func transform(input: Input) -> Output {
+        let initialLoadURL = input.viewDidLoad
+            .compactMap { [initialURL = context.initialURL] in
+                initialURL
+            }
+
+        let route = input.homeTap
+            .map { SessionRoute.home }
+
+        return Output(
+            initialLoadURL: initialLoadURL,
+            route: route
+        )
+    }
+}

--- a/Modules/FeatureSession/Sources/SessionView/SessionViewModel.swift
+++ b/Modules/FeatureSession/Sources/SessionView/SessionViewModel.swift
@@ -8,10 +8,12 @@
 import Foundation
 import RxCocoa
 
+/// Session 화면에서 사용자가 의도한 화면 이동을 표현합니다.
 enum SessionRoute: Equatable {
     case home
 }
 
+/// Session 진입 입력을 WebView load command와 화면 route로 바꿉니다.
 final class SessionViewModel {
     struct Input {
         let viewDidLoad: Signal<Void>

--- a/Modules/FeatureSession/Sources/SessionWeb/SessionBrowserState.swift
+++ b/Modules/FeatureSession/Sources/SessionWeb/SessionBrowserState.swift
@@ -1,0 +1,20 @@
+//
+//  SessionBrowserState.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/9/26.
+//
+
+import Foundation
+
+struct SessionBrowserState: Equatable {
+    let currentURL: URL?
+    let isLoading: Bool
+    let canGoBack: Bool
+
+    static let empty = SessionBrowserState(
+        currentURL: nil,
+        isLoading: false,
+        canGoBack: false
+    )
+}

--- a/Modules/FeatureSession/Sources/SessionWeb/SessionBrowserState.swift
+++ b/Modules/FeatureSession/Sources/SessionWeb/SessionBrowserState.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// Session WebView가 화면에 알려야 하는 URL, loading, back 가능 상태입니다.
 struct SessionBrowserState: Equatable {
     let currentURL: URL?
     let isLoading: Bool

--- a/Modules/FeatureSession/Sources/SessionWeb/SessionWebNavigationFailure.swift
+++ b/Modules/FeatureSession/Sources/SessionWeb/SessionWebNavigationFailure.swift
@@ -7,11 +7,13 @@
 
 import Foundation
 
+/// Session WebView navigation 실패를 후속 fallback이나 logging에서 다루게 합니다.
 enum SessionWebNavigationFailure: Error, Equatable {
     case committed(SessionWebNavigationFailureContext)
     case provisional(SessionWebNavigationFailureContext)
 }
 
+/// WebKit error를 비교 가능한 navigation failure 값으로 보관합니다.
 struct SessionWebNavigationFailureContext: Equatable {
     let domain: String
     let code: Int

--- a/Modules/FeatureSession/Sources/SessionWeb/SessionWebNavigationFailure.swift
+++ b/Modules/FeatureSession/Sources/SessionWeb/SessionWebNavigationFailure.swift
@@ -1,0 +1,26 @@
+//
+//  SessionWebNavigationFailure.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/19/26.
+//
+
+import Foundation
+
+enum SessionWebNavigationFailure: Error, Equatable {
+    case committed(SessionWebNavigationFailureContext)
+    case provisional(SessionWebNavigationFailureContext)
+}
+
+struct SessionWebNavigationFailureContext: Equatable {
+    let domain: String
+    let code: Int
+    let message: String
+
+    init(error: Error) {
+        let error = error as NSError
+        domain = error.domain
+        code = error.code
+        message = error.localizedDescription
+    }
+}

--- a/Modules/FeatureSession/Sources/SessionWeb/SessionWebView.swift
+++ b/Modules/FeatureSession/Sources/SessionWeb/SessionWebView.swift
@@ -1,0 +1,122 @@
+//
+//  SessionWebView.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/9/26.
+//
+
+import UIKit
+import WebKit
+
+import RxCocoa
+import RxRelay
+
+final class SessionWebView: UIView {
+    var state: Driver<SessionBrowserState> {
+        stateRelay.asDriver()
+    }
+
+
+    var currentURL: URL? {
+        webView.url
+    }
+
+    var canGoBack: Bool {
+        webView.canGoBack
+    }
+
+    private let webView: WKWebView
+    private let stateRelay = BehaviorRelay(value: SessionBrowserState.empty)
+    private var observations: [NSKeyValueObservation] = []
+
+    override init(frame: CGRect) {
+        webView = WKWebView(frame: .zero)
+        super.init(frame: frame)
+        configureView()
+        observeBrowserState()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    func load(url: URL) {
+        webView.load(URLRequest(url: url))
+    }
+
+    func goBack() {
+        guard webView.canGoBack else {
+            return
+        }
+
+        webView.goBack()
+    }
+
+    private func configureView() {
+        backgroundColor = .systemBackground
+
+        webView.navigationDelegate = self
+        webView.allowsBackForwardNavigationGestures = true
+        webView.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(webView)
+
+        NSLayoutConstraint.activate([
+            webView.topAnchor.constraint(equalTo: topAnchor),
+            webView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            webView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+
+    private func observeBrowserState() {
+        observations = [
+            webView.observe(\.url, options: [.new]) { [weak self] _, _ in
+                self?.emitState()
+            },
+            webView.observe(\.isLoading, options: [.new]) { [weak self] _, _ in
+                self?.emitState()
+            },
+            webView.observe(\.canGoBack, options: [.new]) { [weak self] _, _ in
+                self?.emitState()
+            }
+        ]
+    }
+
+    private func emitState() {
+        stateRelay.accept(
+            SessionBrowserState(
+                currentURL: webView.url,
+                isLoading: webView.isLoading,
+                canGoBack: webView.canGoBack
+            )
+        )
+    }
+}
+
+extension SessionWebView: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        emitState()
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        emitState()
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFail navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        emitState()
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        emitState()
+    }
+}

--- a/Modules/FeatureSession/Sources/SessionWeb/SessionWebView.swift
+++ b/Modules/FeatureSession/Sources/SessionWeb/SessionWebView.swift
@@ -11,6 +11,7 @@ import WebKit
 import RxCocoa
 import RxRelay
 
+/// Session 안에서 웹 탐색을 담당하고 WebKit detail을 wrapper 뒤에 숨깁니다.
 final class SessionWebView: UIView {
     var state: Driver<SessionBrowserState> {
         stateRelay.asDriver()

--- a/Modules/FeatureSession/Sources/SessionWeb/SessionWebView.swift
+++ b/Modules/FeatureSession/Sources/SessionWeb/SessionWebView.swift
@@ -16,6 +16,9 @@ final class SessionWebView: UIView {
         stateRelay.asDriver()
     }
 
+    var navigationFailure: Signal<SessionWebNavigationFailure> {
+        navigationFailureRelay.asSignal()
+    }
 
     var currentURL: URL? {
         webView.url
@@ -27,6 +30,7 @@ final class SessionWebView: UIView {
 
     private let webView: WKWebView
     private let stateRelay = BehaviorRelay(value: SessionBrowserState.empty)
+    private let navigationFailureRelay = PublishRelay<SessionWebNavigationFailure>()
     private var observations: [NSKeyValueObservation] = []
 
     override init(frame: CGRect) {
@@ -110,6 +114,9 @@ extension SessionWebView: WKNavigationDelegate {
         withError error: Error
     ) {
         emitState()
+        navigationFailureRelay.accept(
+            .committed(SessionWebNavigationFailureContext(error: error))
+        )
     }
 
     func webView(
@@ -118,5 +125,8 @@ extension SessionWebView: WKNavigationDelegate {
         withError error: Error
     ) {
         emitState()
+        navigationFailureRelay.accept(
+            .provisional(SessionWebNavigationFailureContext(error: error))
+        )
     }
 }

--- a/Modules/FeatureSession/Tests/SessionView/SessionViewModelTests.swift
+++ b/Modules/FeatureSession/Tests/SessionView/SessionViewModelTests.swift
@@ -1,0 +1,91 @@
+//
+//  SessionViewModelTests.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/9/26.
+//
+
+import XCTest
+
+import RxCocoa
+import RxRelay
+import RxSwift
+
+@testable import FeatureSession
+
+final class SessionViewModelTests: XCTestCase {
+    private var disposeBag: DisposeBag!
+
+    override func setUp() {
+        super.setUp()
+        disposeBag = DisposeBag()
+    }
+
+    override func tearDown() {
+        disposeBag = nil
+        super.tearDown()
+    }
+
+    func test_viewDidLoadWithInitialURL_emitsInitialURL_readyForBrowsing() {
+        let initialURL = URL(string: "https://www.google.com")!
+        let viewDidLoadRelay = PublishRelay<Void>()
+        let output = makeOutput(
+            context: SessionLaunchContext(sessionId: UUID(), initialURL: initialURL),
+            viewDidLoad: viewDidLoadRelay.asSignal()
+        )
+        var loadedURLs: [URL] = []
+
+        output.initialLoadURL
+            .emit(onNext: { loadedURLs.append($0) })
+            .disposed(by: disposeBag)
+
+        viewDidLoadRelay.accept(())
+
+        XCTAssertEqual(loadedURLs, [initialURL])
+    }
+
+    func test_viewDidLoadWithoutInitialURL_doesNotEmitInitialURL_readyForEmptySession() {
+        let viewDidLoadRelay = PublishRelay<Void>()
+        let output = makeOutput(
+            context: SessionLaunchContext(sessionId: UUID(), initialURL: nil),
+            viewDidLoad: viewDidLoadRelay.asSignal()
+        )
+        var loadedURLs: [URL] = []
+
+        output.initialLoadURL
+            .emit(onNext: { loadedURLs.append($0) })
+            .disposed(by: disposeBag)
+
+        viewDidLoadRelay.accept(())
+
+        XCTAssertTrue(loadedURLs.isEmpty)
+    }
+
+    func test_homeTap_emitsHomeRoute_forExplicitSessionExit() {
+        let homeTapRelay = PublishRelay<Void>()
+        let output = makeOutput(homeTap: homeTapRelay.asSignal())
+        var routes: [SessionRoute] = []
+
+        output.route
+            .emit(onNext: { routes.append($0) })
+            .disposed(by: disposeBag)
+
+        homeTapRelay.accept(())
+
+        XCTAssertEqual(routes, [.home])
+    }
+
+    private func makeOutput(
+        context: SessionLaunchContext = SessionLaunchContext(sessionId: UUID()),
+        viewDidLoad: Signal<Void> = Signal.empty(),
+        homeTap: Signal<Void> = Signal.empty()
+    ) -> SessionViewModel.Output {
+        let viewModel = SessionViewModel(context: context)
+        return viewModel.transform(
+            input: SessionViewModel.Input(
+                viewDidLoad: viewDidLoad,
+                homeTap: homeTap
+            )
+        )
+    }
+}

--- a/Modules/FeatureSession/Tests/SessionView/SessionViewModelTests.swift
+++ b/Modules/FeatureSession/Tests/SessionView/SessionViewModelTests.swift
@@ -13,6 +13,7 @@ import RxSwift
 
 @testable import FeatureSession
 
+/// Session 진입과 Home route가 ViewModel output으로 드러나는지 확인합니다.
 final class SessionViewModelTests: XCTestCase {
     private var disposeBag: DisposeBag!
 

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
+      "state" : {
+        "revision" : "132aea4f236ccadc51590b38af0357a331d51fa2",
+        "version" : "6.10.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 5.9
+
+//
+//  Package.swift
+//  Clipy
+//
+//  Created by 박민서 on 5/9/26.
+//
+
+import PackageDescription
+
+let package = Package(
+    name: "ClipyDependencies",
+    dependencies: [
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.10.2")
+    ]
+)


### PR DESCRIPTION
  ## 무엇을 바꿨나요?

  Session 화면의 기본 틀과 WebView 연결 지점을 `FeatureSession` module로 추가했습니다.
  - Session shell은 WebView, 상단 action, 이후 붙을 bottom sheet와 decision flow가 함께 놓일 화면 틀입니다.
  - WebView wrapper는 `WKWebView`를 직접 노출하지 않고 load 상태와 navigation event를 Feature 내부에서 다루게 하는 UI component입니다.

  ## 왜 바꿨나요?

  Session 안에서 browsing, item 수집, bottom sheet, decision flow가 이어지려면 먼저 화면 shell과 WebView 구조가 필요했습니다.
  이번 PR은 Web View와 Session Shell에 이후 Session 기능을 붙일 수 있는 구조를 준비하는 PR입니다.

  ## 변경 범위

  - `FeatureSession` module 추가
  - `SessionFeature`, `SessionLaunchContext` 공개 진입 API 추가
  - `SessionView`, `SessionViewController`, `SessionViewModel` 구성
  - `SessionWebView` wrapper와 browser state 구성
  - `Docs/Open/PROJECT_STRUCTURE.md` 갱신

  ## 제외한 범위

  - `SessionSnapshot`, `SessionRepository`, `SessionViewState` 연결
  - Bottom Sheet 다음 작업 예정
  - WebView history 저장/복원
  - SwiftLint / SwiftFormat 도입 

  ## 확인한 내용

  - [x] `mise exec -- tuist generate`
  - [x] 화면 변경이 있으면 simulator에서 happy path 확인
  - [x] 새 dependency가 있다면 추가 이유 확인
  - [x] 생성된 `.xcodeproj`, `.xcworkspace`, `Derived/` 미포함 확인

  ## 테스트와 문서

  - initial URL이 있으면 WebView load command를 emit하는지 확인
  - initial URL이 없으면 빈 Session 진입 상태를 유지하는지 확인
  - Home tap이 Session exit route로 이어지는지 확인

  ## 관련 이슈

  Closes #12
  Related: CLIPY-42
