### PR TITLE
CI validate GitHub token 주입

### DIFF
--- a/.github/workflows/ios-baseline.yml
+++ b/.github/workflows/ios-baseline.yml
@@ -34,6 +34,8 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install tools
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mise trust --yes
           mise install


### PR DESCRIPTION
  ## 무엇을 바꿨나요?

  GitHub Actions `iOS Baseline` workflow의 `Install tools` step에 `GITHUB_TOKEN` 환경변수를 추가했습니다.
  `mise install`이 GitHub API를 인증된 요청으로 사용할 수 있게 해서, GitHub Actions runner 환경에서 API Rate Limit 때문에 Tuist
  설치가 실패하는 문제를 줄입니다.

  ## 왜 바꿨나요?

  CI `validate` 잡이 `mise install` 단계에서 GitHub API Rate Limit 초과로 실패했습니다.
  `secrets.GITHUB_TOKEN`은 GitHub Actions에서 기본 제공되므로 별도 secret 추가 없이 적용할 수 있습니다.

  ## 변경 범위

  - `.github/workflows/ios-baseline.yml`
    - `Install tools` step에 `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` 주입

  ## 확인한 내용

  - [x] `mise exec -- tuist generate`
  - [x] `./scripts/validate_ios_baseline.sh` 또는 필요한 경우 `CLIPY_IOS_VALIDATION_MODE=test ./scripts/validate_ios_baseline.sh` 확인
  - [x] 생성된 `.xcodeproj`, `.xcworkspace`, `Derived/` 미포함 확인

  추가 확인:

  - `GITHUB_TOKEN="$(gh auth token)" mise install`
  - `mise exec -- tuist version` -> `4.188.0`
  - `actionlint .github/workflows/ios-baseline.yml`
  - `git diff --check`
  - `bash -n scripts/validate_ios_baseline.sh`
  - `CLIPY_IOS_VALIDATION_MODE=test ./scripts/validate_ios_baseline.sh`
