### PR TITLE
[CLIPY-92] Tuist 모듈 의존성 구조 정리

### DIFF
--- a/Docs/Open/PROJECT_STRUCTURE.md
+++ b/Docs/Open/PROJECT_STRUCTURE.md
@@ -95,6 +95,33 @@ Core -x-> Feature
 Feature끼리는 직접 의존하지 않습니다.
 공유해야 하는 규칙이나 타입이 생기면 먼저 Core 책임인지 봅니다.
 
+## Tuist manifest 작성 기준
+
+module `Project.swift`는 직접 `TargetDependency`를 조립하지 않고, 역할별 helper를 통해 target을 만듭니다.
+
+| 역할 | helper |
+| --- | --- |
+| App target | `ClipyModuleFactory.makeApp` |
+| Core framework | `ClipyModuleFactory.makeCore` |
+| Feature framework | `ClipyModuleFactory.makeFeature` |
+
+의존성은 `ClipyDependencies`에 모아두고, App/Core/Feature 역할에 맞는 typed dependency로 표현합니다.
+module 이름과 bundle suffix는 module identifier에서 읽고, `Project.swift`는 어떤 module을 만들지 선언하는 쪽에 가깝게 둡니다.
+이렇게 두면 module이 늘어나도 의존 방향과 target 이름을 `Project.swift`마다 다시 해석하지 않아도 됩니다.
+
+module 하나만 확인할 때는 아래 command를 씁니다.
+
+```bash
+./scripts/validate_ios_module.sh CoreDomain
+./scripts/validate_ios_module.sh FeatureSession
+```
+
+기본은 `test` mode입니다. build만 확인하려면 기존 validation 환경변수를 그대로 씁니다.
+
+```bash
+CLIPY_IOS_VALIDATION_MODE=build-for-testing ./scripts/validate_ios_module.sh FeatureSession
+```
+
 ## DI 조립 위치
 
 DIContainer는 `AppMain`에서 시작합니다.

--- a/Modules/AppMain/Project.swift
+++ b/Modules/AppMain/Project.swift
@@ -9,10 +9,6 @@ import ProjectDescription
 import ProjectDescriptionHelpers
 
 let project = ClipyModuleFactory.makeApp(
-    name: "AppMain",
-    bundleIdSuffix: "app",
-    dependencies: [
-        .project(target: "FeatureSession", path: .relativeToRoot("Modules/FeatureSession")),
-        .project(target: "CorePersistence", path: .relativeToRoot("Modules/CorePersistence"))
-    ]
+    module: .appMain,
+    dependencies: ClipyDependencies.appMain
 )

--- a/Modules/CoreDomain/Project.swift
+++ b/Modules/CoreDomain/Project.swift
@@ -8,7 +8,7 @@
 import ProjectDescription
 import ProjectDescriptionHelpers
 
-let project = ClipyModuleFactory.makeFramework(
-    name: "CoreDomain",
-    bundleIdSuffix: "core-domain"
+let project = ClipyModuleFactory.makeCore(
+    module: .coreDomain,
+    dependencies: ClipyDependencies.coreDomain
 )

--- a/Modules/CorePersistence/Project.swift
+++ b/Modules/CorePersistence/Project.swift
@@ -8,12 +8,9 @@
 import ProjectDescription
 import ProjectDescriptionHelpers
 
-let project = ClipyModuleFactory.makeFramework(
-    name: "CorePersistence",
-    bundleIdSuffix: "core-persistence",
-    dependencies: [
-        .project(target: "CoreDomain", path: .relativeToRoot("Modules/CoreDomain"))
-    ],
+let project = ClipyModuleFactory.makeCore(
+    module: .corePersistence,
+    dependencies: ClipyDependencies.corePersistence,
     coreDataModels: [
         .coreDataModel("Resources/ClipyPersistence.xcdatamodeld")
     ]

--- a/Modules/FeatureSession/Project.swift
+++ b/Modules/FeatureSession/Project.swift
@@ -8,14 +8,8 @@
 import ProjectDescription
 import ProjectDescriptionHelpers
 
-let project = ClipyModuleFactory.makeFramework(
-    name: "FeatureSession",
-    bundleIdSuffix: "feature-session",
-    dependencies: [
-        .external(name: "RxSwift"),
-        .external(name: "RxCocoa"),
-        .external(name: "RxRelay"),
-        .project(target: "CoreDomain", path: .relativeToRoot("Modules/CoreDomain"))
-    ],
+let project = ClipyModuleFactory.makeFeature(
+    module: .featureSession,
+    dependencies: ClipyDependencies.featureSession,
     hasTests: true
 )

--- a/Tuist/ProjectDescriptionHelpers/ClipyModuleDependencies.swift
+++ b/Tuist/ProjectDescriptionHelpers/ClipyModuleDependencies.swift
@@ -1,0 +1,27 @@
+//
+//  ClipyModuleDependencies.swift
+//  Clipy
+//
+//  Created by 박민서 on 6/11/26.
+//
+
+/// 현재 module graph를 한 곳에서 읽기 위한 dependency map입니다.
+public enum ClipyDependencies {
+    public static let appMain: [AppDependency] = [
+        .feature(.featureSession),
+        .core(.corePersistence)
+    ]
+
+    public static let coreDomain: [CoreDependency] = []
+
+    public static let corePersistence: [CoreDependency] = [
+        .core(.coreDomain)
+    ]
+
+    public static let featureSession: [FeatureDependency] = [
+        .external(.rxSwift),
+        .external(.rxCocoa),
+        .external(.rxRelay),
+        .core(.coreDomain)
+    ]
+}

--- a/Tuist/ProjectDescriptionHelpers/ClipyModuleDependencyMapping.swift
+++ b/Tuist/ProjectDescriptionHelpers/ClipyModuleDependencyMapping.swift
@@ -1,0 +1,55 @@
+//
+//  ClipyModuleDependencyMapping.swift
+//  Clipy
+//
+//  Created by 박민서 on 6/11/26.
+//
+
+import ProjectDescription
+
+extension AppDependency {
+    var targetDependency: TargetDependency {
+        switch self {
+        case let .core(module):
+            return module.targetDependency
+        case let .feature(module):
+            return module.targetDependency
+        case let .external(dependency):
+            return dependency.targetDependency
+        }
+    }
+}
+
+extension CoreDependency {
+    var targetDependency: TargetDependency {
+        switch self {
+        case let .core(module):
+            return module.targetDependency
+        case let .external(dependency):
+            return dependency.targetDependency
+        }
+    }
+}
+
+extension FeatureDependency {
+    var targetDependency: TargetDependency {
+        switch self {
+        case let .core(module):
+            return module.targetDependency
+        case let .external(dependency):
+            return dependency.targetDependency
+        }
+    }
+}
+
+private extension ClipyModuleIdentifiable {
+    var targetDependency: TargetDependency {
+        .project(target: name, path: projectPath)
+    }
+}
+
+private extension ExternalDependency {
+    var targetDependency: TargetDependency {
+        .external(name: packageName)
+    }
+}

--- a/Tuist/ProjectDescriptionHelpers/ClipyModuleDependencyTypes.swift
+++ b/Tuist/ProjectDescriptionHelpers/ClipyModuleDependencyTypes.swift
@@ -1,0 +1,43 @@
+//
+//  ClipyModuleDependencyTypes.swift
+//  Clipy
+//
+//  Created by 박민서 on 6/11/26.
+//
+
+/// Tuist Package dependency를 manifest에서 raw string 없이 고르기 위한 enum입니다.
+public enum ExternalDependency {
+    case rxSwift
+    case rxCocoa
+    case rxRelay
+
+    var packageName: String {
+        switch self {
+        case .rxSwift:
+            return "RxSwift"
+        case .rxCocoa:
+            return "RxCocoa"
+        case .rxRelay:
+            return "RxRelay"
+        }
+    }
+}
+
+/// Core module이 의존할 수 있는 대상입니다. Feature module은 여기서 열지 않습니다.
+public enum CoreDependency {
+    case core(CoreModule)
+    case external(ExternalDependency)
+}
+
+/// Feature module이 의존할 수 있는 대상입니다. Feature끼리 직접 연결하지 않습니다.
+public enum FeatureDependency {
+    case core(CoreModule)
+    case external(ExternalDependency)
+}
+
+/// App target이 composition root로 조립할 수 있는 대상입니다.
+public enum AppDependency {
+    case core(CoreModule)
+    case feature(FeatureModule)
+    case external(ExternalDependency)
+}

--- a/Tuist/ProjectDescriptionHelpers/ClipyModuleFactory.swift
+++ b/Tuist/ProjectDescriptionHelpers/ClipyModuleFactory.swift
@@ -8,61 +8,75 @@
 import ProjectDescription
 
 public enum ClipyModuleFactory {
+    /// App target과 test target, shared scheme을 함께 만듭니다.
     public static func makeApp(
-        name: String,
-        bundleIdSuffix: String,
-        dependencies: [TargetDependency] = [],
+        module: AppModule,
+        dependencies: [AppDependency] = [],
         hasTests: Bool = true
     ) -> Project {
         var targets: [Target] = [
             .target(
-                name: name,
+                name: module.name,
                 destinations: ClipyProjectConfig.defaultDestinations,
                 product: .app,
-                bundleId: "\(ClipyProjectConfig.bundleIdPrefix).\(bundleIdSuffix)",
+                bundleId: "\(ClipyProjectConfig.bundleIdPrefix).\(module.bundleIdSuffix)",
                 deploymentTargets: ClipyProjectConfig.deploymentTargets,
                 infoPlist: .extendingDefault(with: ClipyProjectConfig.baseInfoPlist),
                 sources: ["\(ClipyProjectConfig.sourcesDirectory)/**"],
-                dependencies: dependencies
+                dependencies: dependencies.map(\.targetDependency)
             )
         ]
 
         if hasTests {
-            targets.append(
-                .target(
-                    name: "\(name)Tests",
-                    destinations: ClipyProjectConfig.defaultDestinations,
-                    product: .unitTests,
-                    bundleId: "\(ClipyProjectConfig.bundleIdPrefix).\(bundleIdSuffix).tests",
-                    deploymentTargets: ClipyProjectConfig.deploymentTargets,
-                    infoPlist: .default,
-                    sources: ["\(ClipyProjectConfig.testsDirectory)/**"],
-                    dependencies: [.target(name: name)]
-                )
-            )
+            targets.append(makeTestTarget(for: module))
         }
 
-        return Project(
-            name: name,
-            options: .options(automaticSchemesOptions: .disabled),
-            targets: targets,
-            schemes: [makeScheme(name: name, hasTests: hasTests)]
+        return makeProject(module: module, targets: targets, hasTests: hasTests)
+    }
+
+    /// Core framework target을 만듭니다. CoreData model은 persistence module처럼 필요한 Core에서만 넘깁니다.
+    public static func makeCore(
+        module: CoreModule,
+        dependencies: [CoreDependency] = [],
+        hasTests: Bool = true,
+        coreDataModels: [CoreDataModel] = []
+    ) -> Project {
+        makeFramework(
+            module: module,
+            dependencies: dependencies.map(\.targetDependency),
+            hasTests: hasTests,
+            coreDataModels: coreDataModels
         )
     }
 
-    public static func makeFramework(
-        name: String,
-        bundleIdSuffix: String,
-        dependencies: [TargetDependency] = [],
+    /// Feature framework target을 만듭니다. Feature끼리 직접 연결하지 않는 dependency shape를 받습니다.
+    public static func makeFeature(
+        module: FeatureModule,
+        dependencies: [FeatureDependency] = [],
+        hasTests: Bool = true
+    ) -> Project {
+        makeFramework(
+            module: module,
+            dependencies: dependencies.map(\.targetDependency),
+            hasTests: hasTests
+        )
+    }
+}
+
+private extension ClipyModuleFactory {
+
+    static func makeFramework(
+        module: some ClipyModuleIdentifiable,
+        dependencies: [TargetDependency],
         hasTests: Bool = true,
         coreDataModels: [CoreDataModel] = []
     ) -> Project {
         var targets: [Target] = [
             .target(
-                name: name,
+                name: module.name,
                 destinations: ClipyProjectConfig.defaultDestinations,
                 product: .framework,
-                bundleId: "\(ClipyProjectConfig.bundleIdPrefix).\(bundleIdSuffix)",
+                bundleId: "\(ClipyProjectConfig.bundleIdPrefix).\(module.bundleIdSuffix)",
                 deploymentTargets: ClipyProjectConfig.deploymentTargets,
                 infoPlist: .default,
                 sources: ["\(ClipyProjectConfig.sourcesDirectory)/**"],
@@ -72,29 +86,39 @@ public enum ClipyModuleFactory {
         ]
 
         if hasTests {
-            targets.append(
-                .target(
-                    name: "\(name)Tests",
-                    destinations: ClipyProjectConfig.defaultDestinations,
-                    product: .unitTests,
-                    bundleId: "\(ClipyProjectConfig.bundleIdPrefix).\(bundleIdSuffix).tests",
-                    deploymentTargets: ClipyProjectConfig.deploymentTargets,
-                    infoPlist: .default,
-                    sources: ["\(ClipyProjectConfig.testsDirectory)/**"],
-                    dependencies: [.target(name: name)]
-                )
-            )
+            targets.append(makeTestTarget(for: module))
         }
 
-        return Project(
-            name: name,
+        return makeProject(module: module, targets: targets, hasTests: hasTests)
+    }
+
+    static func makeProject(
+        module: some ClipyModuleIdentifiable,
+        targets: [Target],
+        hasTests: Bool
+    ) -> Project {
+        Project(
+            name: module.name,
             options: .options(automaticSchemesOptions: .disabled),
             targets: targets,
-            schemes: [makeScheme(name: name, hasTests: hasTests)]
+            schemes: [makeScheme(name: module.name, hasTests: hasTests)]
         )
     }
 
-    private static func makeScheme(name: String, hasTests: Bool) -> Scheme {
+    static func makeTestTarget(for module: some ClipyModuleIdentifiable) -> Target {
+        .target(
+            name: "\(module.name)Tests",
+            destinations: ClipyProjectConfig.defaultDestinations,
+            product: .unitTests,
+            bundleId: "\(ClipyProjectConfig.bundleIdPrefix).\(module.bundleIdSuffix).tests",
+            deploymentTargets: ClipyProjectConfig.deploymentTargets,
+            infoPlist: .default,
+            sources: ["\(ClipyProjectConfig.testsDirectory)/**"],
+            dependencies: [.target(name: module.name)]
+        )
+    }
+
+    static func makeScheme(name: String, hasTests: Bool) -> Scheme {
         Scheme.scheme(
             name: name,
             shared: true,

--- a/Tuist/ProjectDescriptionHelpers/ClipyModuleIdentifiers.swift
+++ b/Tuist/ProjectDescriptionHelpers/ClipyModuleIdentifiers.swift
@@ -1,0 +1,92 @@
+//
+//  ClipyModuleIdentifiers.swift
+//  Clipy
+//
+//  Created by 박민서 on 6/11/26.
+//
+
+import ProjectDescription
+
+/// Tuist helper 내부에서 module 이름, bundle suffix, project path를 한 곳에서 읽기 위한 식별자입니다.
+protocol ClipyModuleIdentifiable {
+    /// Tuist target과 project 이름으로 쓰는 module 이름입니다.
+    var name: String { get }
+
+    /// `com.laxotters.clipy` 뒤에 붙는 module별 bundle id suffix입니다.
+    var bundleIdSuffix: String { get }
+}
+
+extension ClipyModuleIdentifiable {
+    /// `Modules/<module name>` 규칙으로 계산한 Tuist project path입니다.
+    var projectPath: Path {
+        .relativeToRoot("\(ClipyProjectConfig.modulesRoot)/\(name)")
+    }
+}
+
+/// App target으로 생성되는 module입니다.
+public enum AppModule {
+    case appMain
+}
+
+extension AppModule: ClipyModuleIdentifiable {
+    var name: String {
+        switch self {
+        case .appMain:
+            return "AppMain"
+        }
+    }
+
+    var bundleIdSuffix: String {
+        switch self {
+        case .appMain:
+            return "app"
+        }
+    }
+}
+
+/// Domain과 platform 구현처럼 feature 밖에서 공유되는 core module입니다.
+public enum CoreModule {
+    case coreDomain
+    case corePersistence
+}
+
+extension CoreModule: ClipyModuleIdentifiable {
+    var name: String {
+        switch self {
+        case .coreDomain:
+            return "CoreDomain"
+        case .corePersistence:
+            return "CorePersistence"
+        }
+    }
+
+    var bundleIdSuffix: String {
+        switch self {
+        case .coreDomain:
+            return "core-domain"
+        case .corePersistence:
+            return "core-persistence"
+        }
+    }
+}
+
+/// 화면이나 사용자 흐름 단위로 나뉘는 feature module입니다.
+public enum FeatureModule {
+    case featureSession
+}
+
+extension FeatureModule: ClipyModuleIdentifiable {
+    var name: String {
+        switch self {
+        case .featureSession:
+            return "FeatureSession"
+        }
+    }
+
+    var bundleIdSuffix: String {
+        switch self {
+        case .featureSession:
+            return "feature-session"
+        }
+    }
+}

--- a/scripts/validate_ios_module.sh
+++ b/scripts/validate_ios_module.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# PR1에서는 검증 가능한 iOS module을 명시적으로 열어둡니다.
+# module을 추가하면 Tuist manifest와 함께 이 whitelist도 갱신합니다.
+SUPPORTED_SCHEMES=(
+  "AppMain"
+  "CoreDomain"
+  "CorePersistence"
+  "FeatureSession"
+)
+
+usage() {
+  cat >&2 <<USAGE
+Usage: $0 <scheme>
+
+Supported schemes:
+  ${SUPPORTED_SCHEMES[*]}
+
+Environment:
+  CLIPY_IOS_VALIDATION_MODE   test | build-for-testing | build (default: test)
+  CLIPY_IOS_DESTINATION       optional xcodebuild destination override
+  CLIPY_IOS_SIMULATOR_NAME    preferred simulator name for test mode
+USAGE
+}
+
+if [[ "$#" -ne 1 ]]; then
+  usage
+  exit 2
+fi
+
+SCHEME="$1"
+
+is_supported="0"
+for supported_scheme in "${SUPPORTED_SCHEMES[@]}"; do
+  if [[ "$SCHEME" == "$supported_scheme" ]]; then
+    is_supported="1"
+    break
+  fi
+done
+
+if [[ "$is_supported" != "1" ]]; then
+  echo "Unsupported iOS module scheme: ${SCHEME}" >&2
+  usage
+  exit 2
+fi
+
+export CLIPY_IOS_SCHEME="$SCHEME"
+export CLIPY_IOS_VALIDATION_MODE="${CLIPY_IOS_VALIDATION_MODE:-test}"
+
+"$ROOT_DIR/scripts/validate_ios_baseline.sh"


### PR DESCRIPTION
  ## 무엇을 바꿨나요?

  Tuist module manifest를 typed helper 기반으로 정리했습니다.
 이제 각 `Modules/*/Project.swift`가 target 이름, bundle suffix, raw dependency를 직접 조립하지 않고, `ClipyModuleFactory`와 `ClipyDependencies`를 통해 module 역할만 드러내도록 바꿨습니다. 
module 하나만 검증할 수 있는 command도 추가했습니다.


  ## 왜 바꿨나요?

  앞으로 App, Core, Feature module이 늘어날 때 `Project.swift`마다 dependency 방향과 target 이름을 다시 해석하면 구조가 쉽게 흔들릴 수 있습니다.
  이번 작업은 추후 모듈 추가와 분리 작업을 더 안전하게 이어갈 수 있게 Tuist 작성 방식을 먼저 정리하는 작업입니다.

 ## 변경 범위

  - Tuist module identifier와 역할별 typed dependency를 추가했습니다.
  - 현재 구성 모듈 그래프를 `ClipyDependencies`로 합치며, `TargetDependency` 변환은 helper 내부로 이동시켰습니다.
  - `AppMain`, `CoreDomain`, `CorePersistence`, `FeatureSession` manifest에 새 helper를 적용했습니다.
  - module별 검증 command와 public-safe Tuist 작성 기준을 추가했습니다.

  ## 제외한 범위

  - CI module matrix와 policy validation은 다음 작업 진행 예정입니다.
  - xcconfig/signing 분리는 TODO로 남겼습니다.
  - 새 module 추가, product behavior 변경, generated Xcode 파일 포함은 하지 않았습니다.

  ## 확인한 내용

  - [x] `mise exec -- tuist generate`
  - [x] `./scripts/validate_ios_baseline.sh` 또는 필요한 경우 `CLIPY_IOS_VALIDATION_MODE=test ./scripts/
  validate_ios_baseline.sh` 확인
  - [x] 새 dependency가 있다면 추가 이유 확인
  - [x] 생성된 `.xcodeproj`, `.xcworkspace`, `Derived/` 미포함 확인

  ## 테스트와 문서

Tuist manifest 변경을 검증하기 위해 tuist generate와 module별 validation script를 실행했습니다.
  public-safe 개발 기준은 Docs/Open/PROJECT_STRUCTURE.md에 반영했습니다.

## 리뷰어가 특히 봐야 할 부분
  - module 의존성을 바꿀 때 `ClipyDependencies`만 보면 충분한지 봐주세요.
  - App/Core/Feature별 factory가 지금 module 역할을 자연스럽게 드러내는지 봐주세요.
  - 각 `Project.swift`가 세부 Tuist wiring보다 “어떤 module을 만드는지”에 집중해서 읽히는지 봐주세요.
  - `validate_ios_module.sh`의 scheme whitelist가 이번 PR 범위에서는 과하지 않은지 봐주세요.

  ## 관련 이슈
  Related: #19, CLIPY-92