### PR TITLE
[CLIPY-92] Tuist validation profile 라우터 추가

### DIFF
--- a/Docs/Open/PROJECT_STRUCTURE.md
+++ b/Docs/Open/PROJECT_STRUCTURE.md
@@ -116,10 +116,32 @@ module 하나만 확인할 때는 아래 command를 씁니다.
 ./scripts/validate_ios_module.sh FeatureSession
 ```
 
-기본은 `test` mode입니다. build만 확인하려면 기존 validation 환경변수를 그대로 씁니다.
+기본은 `build-for-testing` mode입니다.
+simulator에서 test까지 실행해야 할 때만 `CLIPY_IOS_VALIDATION_MODE=test`를 명시합니다.
 
 ```bash
 CLIPY_IOS_VALIDATION_MODE=build-for-testing ./scripts/validate_ios_module.sh FeatureSession
+```
+
+Tuist manifest 규칙만 빠르게 확인할 때는 아래 command를 씁니다.
+
+```bash
+./scripts/validate_tuist_foundation.sh
+```
+
+이 검증은 module `Project.swift`에서 raw `.project`, `.external`, `TargetDependency` 조립, generic factory 직접 호출이 helper 밖으로 새지 않았는지 확인합니다.
+생성된 `.xcodeproj`, `.xcworkspace`, `Derived/`가 tracked file로 들어오는지도 함께 막습니다.
+tracked file 기준 검증이라서, PR 전에는 `git status --short`로 untracked 생성물도 따로 확인합니다.
+
+작업 범위에 맞는 검증 묶음은 profile router로 실행합니다.
+profile은 검증 방식과 비용을 정하고, module 대상은 scheme 입력으로 분리합니다.
+
+```bash
+CLIPY_IOS_VALIDATION_PROFILE=project-setup ./scripts/validate_ios_profile.sh
+
+CLIPY_IOS_VALIDATION_PROFILE=integration \
+CLIPY_IOS_VALIDATION_SCHEMES=FeatureSession \
+./scripts/validate_ios_profile.sh
 ```
 
 ## DI 조립 위치

--- a/Docs/Open/SETUP.md
+++ b/Docs/Open/SETUP.md
@@ -37,6 +37,60 @@ CLIPY_IOS_VALIDATION_MODE=test \
   ./scripts/validate_ios_baseline.sh
 ```
 
+## 작업 유형별 검증
+
+작업 범위가 명확하면 profile을 골라 필요한 검증만 실행할 수 있습니다.
+profile은 검증 방식과 비용을 정하고, module 대상은 `CLIPY_IOS_VALIDATION_SCHEMES`로 넘깁니다.
+profile router는 기본으로 `build-for-testing`을 사용합니다.
+simulator에서 test까지 실행해야 할 때만 `CLIPY_IOS_VALIDATION_MODE=test`를 명시합니다.
+build가 필요한 profile은 `tuist install`과 `tuist generate`를 한 번 실행한 뒤, 선택된 scheme 검증을 이어서 실행합니다.
+
+```sh
+CLIPY_IOS_VALIDATION_PROFILE=integration \
+CLIPY_IOS_VALIDATION_SCHEMES=FeatureSession \
+  ./scripts/validate_ios_profile.sh
+```
+
+지원하는 profile은 아래와 같습니다.
+
+| Profile | 주로 쓰는 경우 |
+| --- | --- |
+| `docs-only` | 문서와 GitHub template만 변경 |
+| `tuist-foundation` | Tuist manifest 규칙과 generated artifact 확인 |
+| `app-main` | AppMain 조립이나 app entry 변경 |
+| `module` | 지정한 module scheme만 확인 |
+| `integration` | 지정한 module scheme과 AppMain 조립을 함께 확인 |
+| `project-setup` | Tuist manifest, module 구조, project 설정 변경 |
+| `ci` | GitHub Actions나 validation 흐름 변경 |
+
+`module`과 `integration`은 scheme을 같이 넘깁니다.
+
+```sh
+CLIPY_IOS_VALIDATION_PROFILE=module \
+CLIPY_IOS_VALIDATION_SCHEMES="CoreDomain CorePersistence" \
+  ./scripts/validate_ios_profile.sh
+```
+
+어떤 command가 선택되는지만 보고 싶을 때는 dry-run을 씁니다.
+
+```sh
+CLIPY_IOS_VALIDATION_PROFILE=project-setup \
+CLIPY_IOS_VALIDATION_DRY_RUN=1 \
+  ./scripts/validate_ios_profile.sh
+```
+
+`docs-only` profile은 변경 파일을 명시해야 합니다.
+
+```sh
+CLIPY_IOS_VALIDATION_PROFILE=docs-only \
+CLIPY_IOS_CHANGED_FILES=$'Docs/Open/SETUP.md\nDocs/Open/PROJECT_STRUCTURE.md' \
+  ./scripts/validate_ios_profile.sh
+```
+
+`docs-only`는 iOS build를 생략하는 대신, 입력된 파일이 문서나 GitHub template 계열인지 확인합니다.
+generated artifact 확인은 tracked file 기준의 preflight입니다.
+PR을 올리기 전에는 `git status --short`로 untracked 생성물이 섞였는지도 따로 봅니다.
+
 ## Test
 
 test를 직접 실행할 때는 AppMain scheme을 지정합니다.

--- a/scripts/validate_ios_baseline.sh
+++ b/scripts/validate_ios_baseline.sh
@@ -9,13 +9,15 @@ WORKSPACE="${CLIPY_IOS_WORKSPACE:-Clipy.xcworkspace}"
 MODE="${CLIPY_IOS_VALIDATION_MODE:-build-for-testing}"
 DESTINATION="${CLIPY_IOS_DESTINATION:-}"
 SIMULATOR_NAME="${CLIPY_IOS_SIMULATOR_NAME:-iPhone 17 Pro}"
+# 같은 profile 안에서 Tuist generate 결과를 다시 쓸 때만 1로 둡니다.
+# 직접 실행에서 켜면 오래된 workspace를 볼 수 있어서 존재 여부를 먼저 확인합니다.
+SKIP_TUIST_PREP="${CLIPY_IOS_SKIP_TUIST_PREP:-0}"
+EXPECTED_WORKSPACE_PATH="${WORKSPACE%/}"
 XCODEBUILD_ARGS=()
 
-if [[ "${CLIPY_XCODEBUILD_QUIET:-1}" == "1" ]]; then
-  XCODEBUILD_ARGS+=("-quiet")
-fi
-
 resolve_test_destination() {
+  # simulator 목록은 test mode에서만 읽습니다.
+  # build/build-for-testing은 generic destination을 써서 CI에서 시뮬레이터 부팅 비용을 피합니다.
   xcrun simctl list devices available --json | CLIPY_IOS_SIMULATOR_NAME="$SIMULATOR_NAME" python3 -c '
 import json
 import os
@@ -31,6 +33,7 @@ def runtime_version(runtime):
     return tuple(int(part) for part in re.findall(r"\d+", runtime))
 
 
+# 선호 simulator가 없으면 사용 가능한 최신 iPhone runtime을 고릅니다.
 for runtime, runtime_devices in payload.get("devices", {}).items():
     for device in runtime_devices:
         if device.get("isAvailable") and device.get("name", "").startswith("iPhone"):
@@ -46,19 +49,26 @@ print(selected["udid"])
 '
 }
 
-echo "Xcode:"
-xcodebuild -version
+if [[ "${CLIPY_XCODEBUILD_QUIET:-1}" == "1" ]]; then
+  # 기본 로그는 줄이고, 실패 시 xcodebuild의 핵심 error만 보게 둡니다.
+  # 상세 build log가 필요하면 CLIPY_XCODEBUILD_QUIET=0으로 끕니다.
+  XCODEBUILD_ARGS+=("-quiet")
+fi
 
-echo "Tuist:"
-mise exec -- tuist version
-
-echo "Validation mode: ${MODE}"
-
+# mode 선택이 이 스크립트의 비용을 결정합니다.
+# profile router와 직접 실행이 같은 값을 쓰므로, 새 mode를 추가하면 docs도 같이 바꿉니다.
 case "$MODE" in
-  build-for-testing|build)
+  # 기본 검증은 simulator boot 없이 AppMain 조립과 compile 가능 여부만 봅니다.
+  build-for-testing)
     ACTION="build-for-testing"
     DESTINATION="${DESTINATION:-generic/platform=iOS Simulator}"
     ;;
+  # CI 비용을 더 줄여야 할 때는 build mode를 명시해서 더 가볍게 봅니다.
+  build)
+    ACTION="build"
+    DESTINATION="${DESTINATION:-generic/platform=iOS Simulator}"
+    ;;
+  # unit test 실행은 simulator 비용이 있어서 필요한 작업에서만 명시합니다.
   test)
     ACTION="test"
     if [[ -z "$DESTINATION" ]]; then
@@ -73,11 +83,33 @@ case "$MODE" in
     ;;
 esac
 
+# skip flag는 prepare_tuist_workspace가 성공한 뒤에만 안전합니다.
+# workspace가 없으면 하위 script를 단독으로 잘못 실행한 상황이므로 xcodebuild 전에 멈춥니다.
+if [[ "$SKIP_TUIST_PREP" == "1" && ! -d "$EXPECTED_WORKSPACE_PATH" ]]; then
+  echo "CLIPY_IOS_SKIP_TUIST_PREP=1 requires an existing workspace: ${WORKSPACE}" >&2
+  echo "Run validate_ios_profile.sh or unset CLIPY_IOS_SKIP_TUIST_PREP." >&2
+  exit 2
+fi
+
+echo "Xcode:"
+xcodebuild -version
+
+echo "Tuist:"
+mise exec -- tuist version
+
+echo "Validation mode: ${MODE}"
 echo "Using destination: ${DESTINATION}"
 
-mise exec -- tuist install
-mise exec -- tuist generate
+# 직접 실행은 Tuist graph를 다시 만들고, profile 안의 하위 실행만 재사용합니다.
+if [[ "$SKIP_TUIST_PREP" == "1" ]]; then
+  echo "Skipping Tuist install/generate."
+else
+  mise exec -- tuist install
+  mise exec -- tuist generate
+fi
 
+# 여기서부터 Tuist가 만든 workspace/scheme을 xcodebuild로 확인합니다.
+# 실패하면 위쪽 mode/destination/workspace 로그부터 보고 재현 command를 좁힙니다.
 if ((${#XCODEBUILD_ARGS[@]})); then
   xcodebuild "$ACTION" \
     -workspace "$WORKSPACE" \

--- a/scripts/validate_ios_module.sh
+++ b/scripts/validate_ios_module.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-# PR1에서는 검증 가능한 iOS module을 명시적으로 열어둡니다.
-# module을 추가하면 Tuist manifest와 함께 이 whitelist도 갱신합니다.
+# 로컬 검증에서 직접 돌릴 iOS module scheme만 열어둡니다.
+# module을 추가하면 Tuist manifest, profile router, 이 whitelist를 같이 바꿉니다.
+# 직접 실행 기본값은 CI 비용을 고려해 build-for-testing입니다. test가 필요하면 env로 명시합니다.
 SUPPORTED_SCHEMES=(
   "AppMain"
   "CoreDomain"
@@ -16,39 +17,65 @@ SUPPORTED_SCHEMES=(
 usage() {
   cat >&2 <<USAGE
 Usage: $0 <scheme>
+       $0 --check <scheme>
 
 Supported schemes:
   ${SUPPORTED_SCHEMES[*]}
 
 Environment:
-  CLIPY_IOS_VALIDATION_MODE   test | build-for-testing | build (default: test)
+  CLIPY_IOS_VALIDATION_MODE   test | build-for-testing | build (default: build-for-testing)
   CLIPY_IOS_DESTINATION       optional xcodebuild destination override
   CLIPY_IOS_SIMULATOR_NAME    preferred simulator name for test mode
 USAGE
 }
 
+is_supported_scheme() {
+  local scheme="$1"
+  local supported_scheme
+
+  for supported_scheme in "${SUPPORTED_SCHEMES[@]}"; do
+    if [[ "$scheme" == "$supported_scheme" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+if [[ "${1:-}" == "--check" ]]; then
+  if [[ "$#" -ne 2 ]]; then
+    usage
+    exit 2
+  fi
+
+  if is_supported_scheme "$2"; then
+    exit 0
+  fi
+
+  echo "Unsupported iOS module scheme: ${2}" >&2
+  usage
+  exit 2
+fi
+
 if [[ "$#" -ne 1 ]]; then
+  # scheme은 추론하지 않습니다. module 단위 검증은 호출자가 명시한 scheme만 실행합니다.
   usage
   exit 2
 fi
 
 SCHEME="$1"
 
-is_supported="0"
-for supported_scheme in "${SUPPORTED_SCHEMES[@]}"; do
-  if [[ "$SCHEME" == "$supported_scheme" ]]; then
-    is_supported="1"
-    break
-  fi
-done
-
-if [[ "$is_supported" != "1" ]]; then
+# whitelist는 지금 repo에서 단독 검증 대상으로 열어둔 module 목록입니다.
+# Tuist에 scheme이 있어도 이 목록에 없으면 profile router에서 먼저 의도를 정리합니다.
+if ! is_supported_scheme "$SCHEME"; then
+  # 잘못된 scheme 이름은 xcodebuild까지 보내지 않고 여기서 바로 멈춥니다.
   echo "Unsupported iOS module scheme: ${SCHEME}" >&2
   usage
   exit 2
 fi
 
+# 공통 xcodebuild/Tuist 흐름은 baseline script가 맡고, module script는 scheme 선택만 맡습니다.
 export CLIPY_IOS_SCHEME="$SCHEME"
-export CLIPY_IOS_VALIDATION_MODE="${CLIPY_IOS_VALIDATION_MODE:-test}"
+export CLIPY_IOS_VALIDATION_MODE="${CLIPY_IOS_VALIDATION_MODE:-build-for-testing}"
 
 "$ROOT_DIR/scripts/validate_ios_baseline.sh"

--- a/scripts/validate_ios_profile.sh
+++ b/scripts/validate_ios_profile.sh
@@ -1,0 +1,398 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+PROFILE="${CLIPY_IOS_VALIDATION_PROFILE:-}"
+SCHEMES_RAW="${CLIPY_IOS_VALIDATION_SCHEMES:-}"
+DRY_RUN="${CLIPY_IOS_VALIDATION_DRY_RUN:-0}"
+# 기본값은 simulator를 띄우지 않는 build-for-testing입니다.
+# 실제 test가 필요한 작업만 CLIPY_IOS_VALIDATION_MODE=test를 명시합니다.
+export CLIPY_IOS_VALIDATION_MODE="${CLIPY_IOS_VALIDATION_MODE:-build-for-testing}"
+
+usage() {
+  cat >&2 <<USAGE
+Usage: CLIPY_IOS_VALIDATION_PROFILE=<profile> $0
+
+Profiles:
+  project-setup
+  ci
+  app-main
+  tuist-foundation
+  module
+  integration
+  docs-only
+
+Inputs:
+  CLIPY_IOS_VALIDATION_PROFILE   required canonical profile id
+  CLIPY_IOS_VALIDATION_SCHEMES    required for module/integration; comma or whitespace separated scheme names
+  CLIPY_IOS_CHANGED_FILES        optional newline-separated file paths
+  CLIPY_IOS_CHANGED_FILES_FILE   optional file containing newline-separated paths
+  CLIPY_IOS_VALIDATION_DRY_RUN   set to 1 to print the command plan only
+  CLIPY_IOS_VALIDATION_MODE      build-for-testing | build | test (default: build-for-testing)
+USAGE
+}
+
+if [[ -z "$PROFILE" ]]; then
+  # profile이 없으면 넓은 검증으로 추정하지 않습니다.
+  # 비용이 큰 검증을 실수로 돌릴 수 있어서 바로 멈춥니다.
+  echo "CLIPY_IOS_VALIDATION_PROFILE is required." >&2
+  usage
+  exit 2
+fi
+
+# dry-run에서도 mode 오타는 먼저 잡습니다.
+# 잘못된 plan이 PR이나 CI 설정으로 넘어가는 걸 막기 위해서입니다.
+case "$CLIPY_IOS_VALIDATION_MODE" in
+  build-for-testing|build|test)
+    ;;
+  *)
+    echo "Unsupported CLIPY_IOS_VALIDATION_MODE: ${CLIPY_IOS_VALIDATION_MODE}" >&2
+    echo "Use one of: build-for-testing, build, test" >&2
+    exit 2
+    ;;
+esac
+
+PLAN=()
+VALIDATION_SCHEMES=()
+PROJECT_SETUP_SCHEMES=(
+  "CoreDomain"
+  "CorePersistence"
+  "FeatureSession"
+)
+
+# PLAN은 kind|description|command|arg1|arg2 형태로 쌓습니다.
+# dry-run에 보이는 plan과 실제 실행 plan이 갈라지지 않게 같은 배열을 씁니다.
+add_script_step() {
+  local description="$1"
+  local entry="script|${description}"
+  shift
+
+  while (($# > 0)); do
+    entry="${entry}|$1"
+    shift
+  done
+
+  PLAN+=("$entry")
+}
+
+# build-script는 첫 실행 직전에 Tuist workspace를 한 번만 만듭니다.
+# 이후 child script는 같은 workspace를 써서 CI에서 generate를 반복하지 않습니다.
+add_build_step() {
+  local description="$1"
+  local entry="build-script|${description}"
+  shift
+
+  while (($# > 0)); do
+    entry="${entry}|$1"
+    shift
+  done
+
+  PLAN+=("$entry")
+}
+
+add_function_step() {
+  local description="$1"
+  local function_name="$2"
+
+  PLAN+=("function|${description}|${function_name}")
+}
+
+run_command() {
+  # CI 로그에서 실제로 돈 command를 바로 찾을 수 있게 먼저 출력합니다.
+  echo "+ $*"
+  "$@"
+}
+
+format_command() {
+  local first="1"
+
+  while (($# > 0)); do
+    if [[ "$first" == "1" ]]; then
+      printf '%q' "$1"
+      first="0"
+    else
+      printf ' %q' "$1"
+    fi
+    shift
+  done
+}
+
+read_validation_schemes() {
+  local normalized
+  local scheme
+
+  VALIDATION_SCHEMES=()
+  normalized="${SCHEMES_RAW//$'\n'/ }"
+  normalized="${normalized//,/ }"
+
+  set -f
+  for scheme in $normalized; do
+    [[ -z "$scheme" ]] && continue
+    VALIDATION_SCHEMES+=("$scheme")
+  done
+  set +f
+}
+
+check_validation_schemes() {
+  local scheme
+
+  # scheme 오타는 Tuist generate 전에 잡습니다.
+  # 실제 build 검증은 아래 plan에서 같은 validate_ios_module.sh가 다시 맡습니다.
+  for scheme in "${VALIDATION_SCHEMES[@]}"; do
+    "$ROOT_DIR/scripts/validate_ios_module.sh" --check "$scheme"
+  done
+}
+
+require_validation_schemes() {
+  read_validation_schemes
+
+  if ((${#VALIDATION_SCHEMES[@]} == 0)); then
+    echo "${PROFILE} profile requires CLIPY_IOS_VALIDATION_SCHEMES." >&2
+    echo "Example: CLIPY_IOS_VALIDATION_PROFILE=${PROFILE} CLIPY_IOS_VALIDATION_SCHEMES=FeatureSession $0" >&2
+    exit 2
+  fi
+
+  check_validation_schemes
+}
+
+add_module_steps() {
+  local scheme
+
+  require_validation_schemes
+
+  for scheme in "${VALIDATION_SCHEMES[@]}"; do
+    add_build_step "Module ${scheme}" "$ROOT_DIR/scripts/validate_ios_module.sh" "$scheme"
+  done
+}
+
+add_project_setup_module_steps() {
+  local scheme
+
+  VALIDATION_SCHEMES=("${PROJECT_SETUP_SCHEMES[@]}")
+  check_validation_schemes
+
+  for scheme in "${PROJECT_SETUP_SCHEMES[@]}"; do
+    add_build_step "Module ${scheme}" "$ROOT_DIR/scripts/validate_ios_module.sh" "$scheme"
+  done
+}
+
+read_changed_files() {
+  # GitHub API나 label 조회는 PR2에서 붙입니다.
+  # PR1에서는 호출자가 넘긴 changed files만 보고 docs-only 여부를 확인합니다.
+  if [[ -n "${CLIPY_IOS_CHANGED_FILES:-}" ]]; then
+    printf '%s\n' "$CLIPY_IOS_CHANGED_FILES"
+    return
+  fi
+
+  if [[ -n "${CLIPY_IOS_CHANGED_FILES_FILE:-}" ]]; then
+    if [[ ! -f "$CLIPY_IOS_CHANGED_FILES_FILE" ]]; then
+      echo "CLIPY_IOS_CHANGED_FILES_FILE does not exist: ${CLIPY_IOS_CHANGED_FILES_FILE}" >&2
+      exit 2
+    fi
+    cat "$CLIPY_IOS_CHANGED_FILES_FILE"
+  fi
+}
+
+is_docs_only_path() {
+  local path="$1"
+
+  # docs-only는 공개 문서와 GitHub template 변경만 허용합니다.
+  # script, Tuist manifest, source가 섞이면 build를 생략하면 안 됩니다.
+  case "$path" in
+    Docs/*|README.md|Docs.md|AGENTS.md|.github/ISSUE_TEMPLATE/*|.github/PULL_REQUEST_TEMPLATE/*|.github/pull_request_template.md)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+validate_docs_only_changed_files() {
+  local changed_files
+  local invalid_paths=()
+  local path
+
+  # changed files 입력이 없으면 docs-only라고 보지 않습니다.
+  # 첫 구현에서는 자동 diff 분석 대신 명시 입력만 받습니다.
+  changed_files="$(read_changed_files)"
+
+  if [[ -z "$changed_files" ]]; then
+    echo "docs-only profile requires CLIPY_IOS_CHANGED_FILES or CLIPY_IOS_CHANGED_FILES_FILE." >&2
+    exit 2
+  fi
+
+  while IFS= read -r path; do
+    [[ -z "$path" ]] && continue
+    if ! is_docs_only_path "$path"; then
+      invalid_paths+=("$path")
+    fi
+  done <<< "$changed_files"
+
+  if ((${#invalid_paths[@]} > 0)); then
+    # docs-only로 돌렸지만 코드성 파일이 섞인 경우입니다.
+    # 이때는 더 넓은 profile을 골라 다시 실행합니다.
+    echo "docs-only profile received non-doc/template paths:" >&2
+    printf '  %s\n' "${invalid_paths[@]}" >&2
+    exit 1
+  fi
+
+  echo "docs-only changed files check passed."
+}
+
+validate_workflow_yaml() {
+  local workflow_count=0
+  local workflow
+
+  # PR1에서는 workflow를 바꾸지 않지만, ci profile을 로컬에서 확인할 수 있게 syntax만 봅니다.
+  # macOS 기본 Ruby YAML parser로 충분해서 dependency를 새로 넣지 않습니다.
+  while IFS= read -r workflow; do
+    workflow_count=$((workflow_count + 1))
+    ruby --disable-gems -e 'require "yaml"; YAML.load_file(ARGV[0])' "$workflow"
+  done < <(find .github/workflows -type f \( -name '*.yml' -o -name '*.yaml' \) | sort)
+
+  if ((workflow_count == 0)); then
+    echo "No GitHub workflow files found." >&2
+    exit 1
+  fi
+
+  echo "GitHub workflow YAML syntax check passed."
+}
+
+prepare_tuist_workspace() {
+  # GitHub fresh runner에는 생성물이 없으므로 build profile에서는 install/generate를 먼저 돌립니다.
+  # 재사용 신호는 이 함수가 성공한 뒤 child process에만 넘깁니다.
+  echo "Preparing Tuist workspace..."
+  mise exec -- tuist install
+  mise exec -- tuist generate
+}
+
+plan_for_profile() {
+  # profile은 검증 방식과 비용을 정하고, scheme 입력은 검증 대상을 정합니다.
+  # 새 module을 추가하면 validate_ios_module.sh whitelist와 필요한 docs를 같이 바꿉니다.
+  case "$PROFILE" in
+    project-setup)
+      # Tuist helper나 manifest 규칙을 건드렸을 때 쓰는 넓은 profile입니다.
+      # 전체 앱 test 대신 AppMain과 현재 공개된 module scheme이 build되는지만 봅니다.
+      add_script_step "Static Tuist policy" "$ROOT_DIR/scripts/validate_tuist_foundation.sh"
+      add_build_step "AppMain baseline" "$ROOT_DIR/scripts/validate_ios_baseline.sh"
+      add_project_setup_module_steps
+      ;;
+    ci)
+      # GitHub label mapping을 붙이기 전까지는 로컬에서 직접 호출하는 CI 성격의 profile입니다.
+      add_script_step "Static Tuist policy" "$ROOT_DIR/scripts/validate_tuist_foundation.sh"
+      add_function_step "GitHub workflow YAML syntax" validate_workflow_yaml
+      add_build_step "AppMain baseline" "$ROOT_DIR/scripts/validate_ios_baseline.sh"
+      ;;
+    app-main)
+      # 앱 진입점이나 공통 wiring만 바뀐 경우 AppMain scheme만 확인합니다.
+      add_build_step "AppMain baseline" "$ROOT_DIR/scripts/validate_ios_baseline.sh"
+      ;;
+    tuist-foundation)
+      # Tuist manifest 규칙과 generated artifact만 빠르게 보고 싶을 때 씁니다.
+      add_script_step "Static Tuist policy" "$ROOT_DIR/scripts/validate_tuist_foundation.sh"
+      ;;
+    module)
+      # 지정한 module scheme만 확인합니다. AppMain 조립까지 볼 필요가 없을 때 씁니다.
+      add_module_steps
+      ;;
+    integration)
+      # 지정한 module scheme과 AppMain 조립을 같이 봅니다.
+      add_module_steps
+      add_build_step "AppMain baseline" "$ROOT_DIR/scripts/validate_ios_baseline.sh"
+      ;;
+    docs-only)
+      # docs-only는 build를 생략하는 대신 changed files로 코드 변경이 섞였는지 확인합니다.
+      add_function_step "Docs-only changed files check" validate_docs_only_changed_files
+      add_script_step "Tracked generated artifact preflight" "$ROOT_DIR/scripts/validate_tuist_foundation.sh" "--generated-artifacts-only"
+      ;;
+    *)
+      echo "Unknown CLIPY_IOS_VALIDATION_PROFILE: ${PROFILE}" >&2
+      usage
+      exit 2
+      ;;
+  esac
+}
+
+print_plan() {
+  local arg1
+  local arg2
+  local command
+  local description
+  local index
+  local kind
+
+  # dry-run도 실제 실행과 같은 PLAN을 봅니다.
+  # 그래서 build 없이도 어떤 검증이 돌지 먼저 리뷰할 수 있습니다.
+  echo "Validation profile: ${PROFILE}"
+  echo "Validation mode: ${CLIPY_IOS_VALIDATION_MODE}"
+  if plan_has_build_step; then
+    echo "Tuist prep: once before the first build step"
+  else
+    echo "Tuist prep: not needed"
+  fi
+  echo "Validation plan:"
+  for index in "${!PLAN[@]}"; do
+    IFS='|' read -r kind description command arg1 arg2 <<< "${PLAN[$index]}"
+    if [[ "$kind" == "script" || "$kind" == "build-script" ]]; then
+      command="$(format_command "$command" ${arg1:+"$arg1"} ${arg2:+"$arg2"})"
+    fi
+    printf '  %d. %s: %s\n' "$((index + 1))" "$description" "$command"
+  done
+}
+
+plan_has_build_step() {
+  local index
+  local kind
+
+  # build step이 하나라도 있으면 Tuist install/generate가 필요합니다.
+  # docs-only처럼 function/script step만 있으면 workspace를 만들지 않습니다.
+  for index in "${!PLAN[@]}"; do
+    IFS='|' read -r kind _ <<< "${PLAN[$index]}"
+    if [[ "$kind" == "build-script" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+execute_plan() {
+  local arg1
+  local arg2
+  local description
+  local index
+  local kind
+  local command
+  local tuist_prepared="0"
+
+  # PLAN 순서대로 실행하되, 첫 build-script 직전에만 Tuist workspace를 만듭니다.
+  # static policy가 실패하면 generate 비용을 쓰기 전에 멈춥니다.
+  for index in "${!PLAN[@]}"; do
+    IFS='|' read -r kind description command arg1 arg2 <<< "${PLAN[$index]}"
+    echo "==> ${description}"
+    if [[ "$kind" == "function" ]]; then
+      # function step은 현재 shell 함수로 실행합니다. docs-only나 yaml syntax처럼 별도 script가 필요 없는 검증입니다.
+      "$command"
+    else
+      if [[ "$kind" == "build-script" && "$tuist_prepared" != "1" ]]; then
+        prepare_tuist_workspace
+        # 이 flag는 방금 만든 workspace를 하위 검증에서만 다시 쓰게 하는 내부 신호입니다.
+        export CLIPY_IOS_SKIP_TUIST_PREP=1
+        tuist_prepared="1"
+      fi
+      run_command "$command" ${arg1:+"$arg1"} ${arg2:+"$arg2"}
+    fi
+  done
+}
+
+plan_for_profile
+print_plan
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  exit 0
+fi
+
+execute_plan

--- a/scripts/validate_tuist_foundation.sh
+++ b/scripts/validate_tuist_foundation.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+MODE="${1:-all}"
+
+# build를 돌리기 전에 바로 잡을 수 있는 Tuist 규칙만 먼저 봅니다.
+# --generated-artifacts-only는 docs-only처럼 build가 필요 없는 흐름에서 생성물만 확인할 때 씁니다.
+if [[ "$MODE" != "all" && "$MODE" != "--generated-artifacts-only" ]]; then
+  echo "Usage: $0 [--generated-artifacts-only]" >&2
+  exit 2
+fi
+
+# 한 번 실행했을 때 고칠 지점을 최대한 같이 보려고 실패 개수만 모읍니다.
+failures=0
+
+report_failure() {
+  local rule="$1"
+  local message="$2"
+
+  echo "${rule}: ${message}" >&2
+  failures=$((failures + 1))
+}
+
+check_pattern_absent() {
+  local rule="$1"
+  local description="$2"
+  local pattern="$3"
+  local matched="0"
+  local matches
+
+  # Tuist helper 안에서는 raw TargetDependency를 만들 수 있습니다.
+  # 여기서는 팀원이 직접 고치는 module manifest만 검사합니다.
+  # rule 메시지는 한 번만 찍고, 실제 위치는 파일:라인으로 모두 보여줍니다.
+  while IFS= read -r manifest; do
+    matches="$(grep -nE "$pattern" "$manifest" || true)"
+    if [[ -n "$matches" ]]; then
+      if [[ "$matched" == "0" ]]; then
+        report_failure "$rule" "$description"
+        matched="1"
+      fi
+      echo "$matches" | sed "s#^#  ${manifest}:#" >&2
+    fi
+  done < <(find Modules -mindepth 2 -maxdepth 2 -name Project.swift -type f | sort)
+}
+
+check_tracked_generated_artifacts() {
+  local generated_files
+
+  # .gitignore가 있어도 이미 tracked 된 생성물은 git ls-files로 봐야 잡힙니다.
+  # 새로 생긴 untracked 생성물은 PR 전에 git status --short로 따로 확인합니다.
+  generated_files="$(git ls-files | grep -E '(^|/)([^/]+\.xcodeproj|[^/]+\.xcworkspace|Derived)(/|$)' || true)"
+
+  if [[ -n "$generated_files" ]]; then
+    report_failure "TUIST005" "tracked generated Xcode artifacts are not allowed"
+    echo "$generated_files" | sed 's/^/  /' >&2
+  fi
+}
+
+if [[ "$MODE" == "all" ]]; then
+  echo "Checking Tuist module manifest policy..."
+  # helper API가 바뀌면 이 rule과 Docs/Open/PROJECT_STRUCTURE.md의 manifest 작성 기준도 같이 바꿉니다.
+  # 새 rule을 추가할 때는 TUIST00x 코드, 실패 메시지, 허용 예외를 한 세트로 맞춥니다.
+  check_pattern_absent "TUIST001" "Modules/*/Project.swift must not use raw .project(...) dependencies" '\.project[[:space:]]*\('
+  check_pattern_absent "TUIST002" "Modules/*/Project.swift must not use raw .external(...) dependencies" '\.external[[:space:]]*\('
+  check_pattern_absent "TUIST003" "Modules/*/Project.swift must not construct TargetDependency directly" '\bTargetDependency\b'
+  check_pattern_absent "TUIST004" "Modules/*/Project.swift must not call generic module factory helpers directly" '\b(makeFramework|makeProject)[[:space:]]*\('
+fi
+
+check_tracked_generated_artifacts
+
+if ((failures > 0)); then
+  echo "Tuist foundation validation failed with ${failures} issue(s)." >&2
+  exit 1
+fi
+
+if [[ "$MODE" == "all" ]]; then
+  echo "Tuist foundation validation passed."
+else
+  echo "Generated artifact preflight passed."
+fi


### PR DESCRIPTION
  ## 무엇을 바꿨나요?

  Tuist 기반 iOS 검증을 작업 유형별로 고를 수 있게 정리했습니다.
  - static Tuist policy 검증을 추가했습니다.
  - `profile + schemes` 방식의 validation 라우터를 추가했습니다.
  - AppMain/module build 검증은 기본적으로 `build-for-testing`으로 돌게 맞췄습니다.
  - 작업 유형별 검증 방법을 공개 문서에 정리했습니다.

  ## 왜 바꿨나요?

  모든 변경에서 같은 검증을 돌리면 로컬과 CI 비용이 커집니다.
  이번 PR에서는 작업 성격에 따라 필요한 검증만 선택할 수 있게 만들었습니다.
  profile은 검증 방식, scheme은 검증 대상으로 분리했습니다.

  ## 변경 범위

  - Tuist manifest 규칙과 generated artifact 유입을 확인하는 static 검증 추가
  - `docs-only`, `tuist-foundation`, `app-main`, `module`, `integration`, `project-setup`, `ci` profile 추가
  - `CLIPY_IOS_VALIDATION_SCHEMES` 기반 module/integration 검증 추가
  - `validate_ios_baseline.sh`, `validate_ios_module.sh`의 기본 검증 mode를 `build-for-testing` 기준으로 정리
  - `Docs/Open/SETUP.md`, `Docs/Open/PROJECT_STRUCTURE.md`에 검증 command와 profile 사용법 반영

  ## 제외한 범위

  - GitHub Actions에서 PR label을 읽어 profile로 매핑하는 작업은 다음 PR에서 작업합니다.
  - xcconfig 분리와 signing 외부 주입은 이번 작업에 포함하지 않았습니다.
  - Swift CLI 전환은 TODO로만 남겼습니다.

  ## 확인한 내용
  - [x] `mise exec -- tuist generate`
  - [x] `./scripts/validate_ios_baseline.sh` 또는 필요한 경우 `CLIPY_IOS_VALIDATION_MODE=test./scripts/validate_ios_baseline.sh` 확인
  - [x] 생성된 `.xcodeproj`, `.xcworkspace`, `Derived/` 미포함 확인

  ## 테스트와 문서
  문서는 아래에 반영했습니다.
  - Docs/Open/SETUP.md
  - Docs/Open/PROJECT_STRUCTURE.md

  ## 리뷰어가 특히 봐야 할 부분

  - profile은 검증 방식과 비용을 나타내고, module 대상은 CLIPY_IOS_VALIDATION_SCHEMES로 넘기는 구조가 적절한지 봐주세요.
  - project-setup에서 Tuist generate를 한 번만 실행하고 하위 scheme 검증이 같은 workspace를 재사용하는 흐름을 봐주세요.
  - docs-only가 build를 생략하는 대신 changed files 입력으로 코드 변경을 막는 방식이 충분한지 봐주세요.
  - validate_tuist_foundation.sh는 lightweight regex 기반 검증입니다. static gate로 충분한지 봐주세요.

  ## 관련 이슈
  Related: #19, CLIPY-92
