### PR TITLE
  [CLIPY-92] PR label 기반 iOS validation 라우팅

### DIFF
--- a/.github/workflows/ios-baseline.yml
+++ b/.github/workflows/ios-baseline.yml
@@ -2,6 +2,13 @@ name: iOS Baseline
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
+      - unlabeled
     paths:
       - ".github/workflows/ios-baseline.yml"
       - ".mise.toml"
@@ -9,8 +16,48 @@ on:
       - "Workspace.swift"
       - "Tuist/**"
       - "Modules/**"
-      - "scripts/validate_ios_baseline.sh"
+      - "scripts/validate_ios_*.sh"
+      - "scripts/validate_tuist_foundation.sh"
+      - "scripts/resolve_ios_validation_from_labels.sh"
+      - "Docs/Open/**"
+      - "Docs/README.md"
+      - "README.md"
+      - "AGENTS.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE/**"
+      - ".github/pull_request_template.md"
   workflow_dispatch:
+    inputs:
+      validation_profile:
+        description: "Validation profile to run"
+        required: true
+        type: choice
+        default: project-setup
+        options:
+          - docs-only
+          - tuist-foundation
+          - app-main
+          - module
+          - integration
+          - project-setup
+          - ci
+      validation_schemes:
+        description: "Optional schemes for module/integration profiles"
+        required: false
+        type: string
+      changed_files:
+        description: "Optional newline-separated changed files for docs-only"
+        required: false
+        type: string
+      validation_mode:
+        description: "xcodebuild validation mode"
+        required: true
+        type: choice
+        default: build-for-testing
+        options:
+          - build-for-testing
+          - build
+          - test
 
 permissions:
   contents: read
@@ -27,6 +74,54 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Collect changed files
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          CHANGED_FILES_PATH: /tmp/clipy_changed_files
+        run: |
+          git fetch origin "$BASE_REF" --depth=1
+          git diff --name-only "origin/${BASE_REF}...HEAD" > "$CHANGED_FILES_PATH"
+          echo "CLIPY_IOS_CHANGED_FILES_FILE=$CHANGED_FILES_PATH" >> "$GITHUB_ENV"
+          echo "Changed files:"
+          cat "$CHANGED_FILES_PATH"
+
+      - name: Resolve validation profile from PR labels
+        if: ${{ github.event_name == 'pull_request' }}
+        run: ./scripts/resolve_ios_validation_from_labels.sh >> "$GITHUB_ENV"
+
+      - name: Configure manual validation profile
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          INPUT_PROFILE: ${{ inputs.validation_profile }}
+          INPUT_SCHEMES: ${{ inputs.validation_schemes }}
+          INPUT_CHANGED_FILES: ${{ inputs.changed_files }}
+          INPUT_MODE: ${{ inputs.validation_mode }}
+          MANUAL_CHANGED_FILES_PATH: /tmp/clipy_manual_changed_files
+        run: |
+          case "$INPUT_SCHEMES" in
+            *$'\n'*|*$'\r'*)
+              echo "validation_schemes must be a single line." >&2
+              exit 2
+              ;;
+          esac
+
+          case "$INPUT_SCHEMES" in
+            *[!A-Za-z0-9_,\ -]*)
+              echo "validation_schemes contains unsupported characters." >&2
+              exit 2
+              ;;
+          esac
+
+          printf '%s\n' "$INPUT_CHANGED_FILES" > "$MANUAL_CHANGED_FILES_PATH"
+
+          printf 'CLIPY_IOS_VALIDATION_PROFILE=%s\n' "$INPUT_PROFILE" >> "$GITHUB_ENV"
+          printf 'CLIPY_IOS_VALIDATION_SCHEMES=%s\n' "$INPUT_SCHEMES" >> "$GITHUB_ENV"
+          printf 'CLIPY_IOS_CHANGED_FILES_FILE=%s\n' "$MANUAL_CHANGED_FILES_PATH" >> "$GITHUB_ENV"
+          printf 'CLIPY_IOS_VALIDATION_MODE=%s\n' "$INPUT_MODE" >> "$GITHUB_ENV"
 
       - name: Install mise
         run: |
@@ -49,5 +144,9 @@ jobs:
           restore-keys: |
             tuist-dependencies-${{ runner.os }}-
 
-      - name: Validate iOS baseline
-        run: ./scripts/validate_ios_baseline.sh
+      - name: Show iOS validation plan
+        run: |
+          CLIPY_IOS_VALIDATION_DRY_RUN=1 ./scripts/validate_ios_profile.sh
+
+      - name: Validate iOS profile
+        run: ./scripts/validate_ios_profile.sh

--- a/Docs/Open/SETUP.md
+++ b/Docs/Open/SETUP.md
@@ -55,7 +55,7 @@ CLIPY_IOS_VALIDATION_SCHEMES=FeatureSession \
 
 | Profile | 주로 쓰는 경우 |
 | --- | --- |
-| `docs-only` | 문서와 GitHub template만 변경 |
+| `docs-only` | 공개 문서와 GitHub template만 변경 |
 | `tuist-foundation` | Tuist manifest 규칙과 generated artifact 확인 |
 | `app-main` | AppMain 조립이나 app entry 변경 |
 | `module` | 지정한 module scheme만 확인 |
@@ -87,7 +87,7 @@ CLIPY_IOS_CHANGED_FILES=$'Docs/Open/SETUP.md\nDocs/Open/PROJECT_STRUCTURE.md' \
   ./scripts/validate_ios_profile.sh
 ```
 
-`docs-only`는 iOS build를 생략하는 대신, 입력된 파일이 문서나 GitHub template 계열인지 확인합니다.
+`docs-only`는 iOS build를 생략하는 대신, 입력된 파일이 `Docs/Open`, root 문서, GitHub template 계열인지 확인합니다.
 generated artifact 확인은 tracked file 기준의 preflight입니다.
 PR을 올리기 전에는 `git status --short`로 untracked 생성물이 섞였는지도 따로 봅니다.
 
@@ -106,10 +106,42 @@ xcodebuild test \
 
 ## CI
 
-GitHub Actions에서는 `iOS Baseline` workflow가 같은 baseline script를 실행합니다.
-CI도 Tuist manifest를 기준으로 project를 생성합니다.
-현재 기본 CI는 `AppMain` build-for-testing까지 확인합니다.
-simulator를 띄우는 full test는 필요한 PR에서 `CLIPY_IOS_VALIDATION_MODE=test`로 별도 확인합니다.
+GitHub Actions에서는 `iOS Baseline` workflow가 PR label을 보고 validation profile을 고릅니다.
+workflow가 label과 changed files를 준비하고, 실제 검증은 local과 같은 `./scripts/validate_ios_profile.sh`가 실행합니다.
+CI도 기본 mode는 `build-for-testing`입니다.
+simulator를 띄우는 full test는 필요한 PR에서 별도로 확인합니다.
+
+| PR label | CI profile | Scheme |
+| --- | --- | --- |
+| `TYPE \| Docs` + `AREA \| Docs` | `docs-only` | 없음 |
+| `AREA \| Project Setup` | `project-setup` | router 내부 기준 |
+| `AREA \| CI` | `ci` | 없음 |
+| `AREA \| AppMain` | `app-main` | 없음 |
+| `AREA \| CoreDomain` | `integration` | `CoreDomain` |
+| `AREA \| CorePersistence` | `integration` | `CorePersistence` |
+| `AREA \| FeatureSession` | `integration` | `FeatureSession` |
+
+module 영역은 CI에서 `module`이 아니라 `integration`으로 확인합니다.
+해당 module만 build되는지보다 AppMain 조립까지 같이 보는 편이 안전하기 때문입니다.
+label이 없거나 지원하지 않는 조합이면 CI는 추정하지 않고 실패합니다.
+`AREA | CI`가 다른 AREA와 같이 있으면 `ci` profile을 우선합니다.
+manual dispatch에서 `docs-only`를 고를 때는 changed files 입력도 같이 넘겨야 합니다.
+
+label mapping만 로컬에서 확인할 수도 있습니다.
+
+```sh
+CLIPY_IOS_PR_LABELS=$'TYPE | Refactor\nAREA | FeatureSession' \
+  ./scripts/resolve_ios_validation_from_labels.sh
+```
+
+위 결과를 profile router dry-run에 넘기면 실제 CI가 어떤 검증을 고르는지 build 없이 확인할 수 있습니다.
+
+```sh
+CLIPY_IOS_VALIDATION_PROFILE=integration \
+CLIPY_IOS_VALIDATION_SCHEMES=FeatureSession \
+CLIPY_IOS_VALIDATION_DRY_RUN=1 \
+  ./scripts/validate_ios_profile.sh
+```
 
 ## Generated files
 

--- a/scripts/resolve_ios_validation_from_labels.sh
+++ b/scripts/resolve_ios_validation_from_labels.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# 로컬 fixture와 GitHub Actions payload가 같은 label 해석 규칙을 타야 CI 라우팅을 재현할 수 있습니다.
+LABELS_RAW="${CLIPY_IOS_PR_LABELS:-}"
+DRY_RUN="${CLIPY_IOS_LABEL_ROUTER_DRY_RUN:-0}"
+
+# GitHub Actions에서는 event payload를, 로컬 fixture에서는 env label 목록을 받습니다.
+# 두 입력은 같은 label list로 정리하고, stdout에는 profile/scheme env만 내보냅니다.
+usage() {
+  cat >&2 <<USAGE
+Usage: CLIPY_IOS_PR_LABELS=<newline-separated labels> $0
+
+Inputs:
+  CLIPY_IOS_PR_LABELS             optional newline-separated GitHub PR label names
+  GITHUB_EVENT_PATH               optional GitHub pull_request event payload path
+  CLIPY_IOS_LABEL_ROUTER_DRY_RUN  set to 1 to print the same env output without CI side effects
+
+Output:
+  CLIPY_IOS_VALIDATION_PROFILE=<profile>
+  CLIPY_IOS_VALIDATION_SCHEMES=<schemes>
+USAGE
+}
+
+read_labels_from_event() {
+  local event_path="${GITHUB_EVENT_PATH:-}"
+
+  if [[ -z "$event_path" ]]; then
+    return 0
+  fi
+
+  if [[ ! -f "$event_path" ]]; then
+    echo "GITHUB_EVENT_PATH does not exist: ${event_path}" >&2
+    exit 2
+  fi
+
+  # GitHub 입력은 PR payload까지만 읽습니다. label 조회 권한이나 네트워크 상태가 CI 라우팅을 바꾸면 안 됩니다.
+  python3 - "$event_path" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as event_file:
+    payload = json.load(event_file)
+
+for label in payload.get("pull_request", {}).get("labels", []):
+    name = label.get("name")
+    if name:
+        print(name)
+PY
+}
+
+read_labels() {
+  if [[ -n "$LABELS_RAW" ]]; then
+    printf '%s\n' "$LABELS_RAW"
+    return
+  fi
+
+  read_labels_from_event
+}
+
+fail() {
+  echo "$1" >&2
+  usage
+  exit 2
+}
+
+# label 분류 기준은 일부러 엄격하게 둡니다.
+# 새 TYPE/AREA를 조용히 통과시키면 PR 변경보다 좁은 profile로 검증될 수 있습니다.
+is_supported_type() {
+  case "$1" in
+    "TYPE | Feature"|"TYPE | Bug"|"TYPE | Refactor"|"TYPE | Docs"|"TYPE | Test"|"TYPE | Chore")
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+is_supported_area() {
+  case "$1" in
+    "AREA | Docs"|"AREA | Project Setup"|"AREA | CI"|"AREA | AppMain"|"AREA | CoreDomain"|"AREA | CorePersistence"|"AREA | FeatureSession")
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+has_area() {
+  local expected="$1"
+  local area_label
+
+  for area_label in "${AREA_LABELS[@]}"; do
+    if [[ "$area_label" == "$expected" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+append_scheme_for_area() {
+  case "$1" in
+    "AREA | CoreDomain")
+      SCHEMES+=("CoreDomain")
+      ;;
+    "AREA | CorePersistence")
+      SCHEMES+=("CorePersistence")
+      ;;
+    "AREA | FeatureSession")
+      SCHEMES+=("FeatureSession")
+      ;;
+  esac
+}
+
+emit_env() {
+  # stdout은 호출자가 그대로 $GITHUB_ENV에 붙입니다.
+  # 사람이 읽는 로그가 섞이면 GitHub env file이 깨지므로 안내는 stderr에만 씁니다.
+  printf 'CLIPY_IOS_VALIDATION_PROFILE=%s\n' "$PROFILE"
+  printf 'CLIPY_IOS_VALIDATION_SCHEMES=%s\n' "$SCHEMES_OUTPUT"
+}
+
+LABELS=()
+TYPE_LABELS=()
+AREA_LABELS=()
+UNSUPPORTED_LABELS=()
+UNSUPPORTED_AREA_LABELS=()
+
+# 여기서부터 입력 label을 TYPE, AREA, 미지원 label로 나눕니다.
+# routing에 쓰지 않는 label도 조용히 무시하지 않습니다. label 기준과 resolver 기준이 달라지는 상황을 빨리 잡기 위해서입니다.
+while IFS= read -r label; do
+  [[ -z "$label" ]] && continue
+  LABELS+=("$label")
+
+  case "$label" in
+    "TYPE | "*)
+      TYPE_LABELS+=("$label")
+      ;;
+    "AREA | "*)
+      AREA_LABELS+=("$label")
+      if ! is_supported_area "$label"; then
+        UNSUPPORTED_AREA_LABELS+=("$label")
+      fi
+      ;;
+    *)
+      UNSUPPORTED_LABELS+=("$label")
+      ;;
+  esac
+done < <(read_labels)
+
+if ((${#LABELS[@]} == 0)); then
+  fail "No GitHub PR labels found. Set CLIPY_IOS_PR_LABELS or provide GITHUB_EVENT_PATH."
+fi
+
+if ((${#UNSUPPORTED_LABELS[@]} > 0)); then
+  echo "Unsupported non-routing labels:" >&2
+  printf '  %s\n' "${UNSUPPORTED_LABELS[@]}" >&2
+  usage
+  exit 2
+fi
+
+if ((${#TYPE_LABELS[@]} != 1)); then
+  echo "Expected exactly one TYPE label, found ${#TYPE_LABELS[@]}." >&2
+  if ((${#TYPE_LABELS[@]} > 0)); then
+    printf '  %s\n' "${TYPE_LABELS[@]}" >&2
+  fi
+  usage
+  exit 2
+fi
+
+if ((${#AREA_LABELS[@]} == 0)); then
+  fail "At least one AREA label is required."
+fi
+
+if ((${#UNSUPPORTED_AREA_LABELS[@]} > 0)); then
+  echo "Unsupported AREA labels:" >&2
+  printf '  %s\n' "${UNSUPPORTED_AREA_LABELS[@]}" >&2
+  usage
+  exit 2
+fi
+
+TYPE_LABEL="${TYPE_LABELS[0]}"
+if ! is_supported_type "$TYPE_LABEL"; then
+  echo "Unsupported TYPE label: ${TYPE_LABEL}" >&2
+  usage
+  exit 2
+fi
+
+PROFILE=""
+SCHEMES=()
+SCHEMES_OUTPUT=""
+
+# docs-only는 build를 생략하는 위험한 profile입니다.
+# TYPE과 AREA가 모두 문서 변경을 가리킬 때만 허용하고, 다른 AREA가 섞이면 바로 실패시킵니다.
+if [[ "$TYPE_LABEL" == "TYPE | Docs" ]]; then
+  if ((${#AREA_LABELS[@]} != 1)) || ! has_area "AREA | Docs"; then
+    echo "TYPE | Docs must be paired only with AREA | Docs." >&2
+    printf 'AREA labels:\n' >&2
+    printf '  %s\n' "${AREA_LABELS[@]}" >&2
+    exit 2
+  fi
+
+  PROFILE="docs-only"
+elif has_area "AREA | Docs"; then
+  echo "AREA | Docs requires TYPE | Docs." >&2
+  exit 2
+elif has_area "AREA | CI"; then
+  # CI label이 섞인 PR은 workflow/YAML 검증을 빼지 않도록 CI profile을 우선합니다.
+  PROFILE="ci"
+elif has_area "AREA | Project Setup"; then
+  PROFILE="project-setup"
+else
+  for area_label in "${AREA_LABELS[@]}"; do
+    append_scheme_for_area "$area_label"
+  done
+
+  # module AREA는 AppMain 조립까지 봐야 하므로 integration profile로 보냅니다.
+  if ((${#SCHEMES[@]} > 0)); then
+    PROFILE="integration"
+    SCHEMES_OUTPUT="${SCHEMES[*]}"
+  elif has_area "AREA | AppMain"; then
+    PROFILE="app-main"
+  else
+    fail "No validation profile mapping found for the provided labels."
+  fi
+fi
+
+if [[ -z "$PROFILE" ]]; then
+  fail "No validation profile mapping found for the provided labels."
+fi
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  echo "Resolved iOS validation labels:" >&2
+  printf '  %s\n' "${LABELS[@]}" >&2
+fi
+
+emit_env

--- a/scripts/validate_ios_baseline.sh
+++ b/scripts/validate_ios_baseline.sh
@@ -9,15 +9,17 @@ WORKSPACE="${CLIPY_IOS_WORKSPACE:-Clipy.xcworkspace}"
 MODE="${CLIPY_IOS_VALIDATION_MODE:-build-for-testing}"
 DESTINATION="${CLIPY_IOS_DESTINATION:-}"
 SIMULATOR_NAME="${CLIPY_IOS_SIMULATOR_NAME:-iPhone 17 Pro}"
-# 같은 profile 안에서 Tuist generate 결과를 다시 쓸 때만 1로 둡니다.
+# validate_ios_profile.sh가 방금 만든 workspace를 재사용할 때만 1로 둡니다.
 # 직접 실행에서 켜면 오래된 workspace를 볼 수 있어서 존재 여부를 먼저 확인합니다.
 SKIP_TUIST_PREP="${CLIPY_IOS_SKIP_TUIST_PREP:-0}"
 EXPECTED_WORKSPACE_PATH="${WORKSPACE%/}"
 XCODEBUILD_ARGS=()
 
+# 실제 Tuist/xcodebuild 실행은 여기로 모읍니다.
+# profile 실행과 직접 실행이 같은 mode/destination 규칙을 쓰게 해서 실패 재현 경로를 줄입니다.
 resolve_test_destination() {
   # simulator 목록은 test mode에서만 읽습니다.
-  # build/build-for-testing은 generic destination을 써서 CI에서 시뮬레이터 부팅 비용을 피합니다.
+  # build/build-for-testing은 generic destination으로 보내 CI에서 시뮬레이터 부팅 비용을 피합니다.
   xcrun simctl list devices available --json | CLIPY_IOS_SIMULATOR_NAME="$SIMULATOR_NAME" python3 -c '
 import json
 import os
@@ -50,20 +52,19 @@ print(selected["udid"])
 }
 
 if [[ "${CLIPY_XCODEBUILD_QUIET:-1}" == "1" ]]; then
-  # 기본 로그는 줄이고, 실패 시 xcodebuild의 핵심 error만 보게 둡니다.
-  # 상세 build log가 필요하면 CLIPY_XCODEBUILD_QUIET=0으로 끕니다.
+  # 기본 로그는 줄이고 실패 지점만 보이게 둡니다. 상세 로그가 필요하면 CLIPY_XCODEBUILD_QUIET=0으로 끕니다.
   XCODEBUILD_ARGS+=("-quiet")
 fi
 
-# mode 선택이 이 스크립트의 비용을 결정합니다.
-# profile router와 직접 실행이 같은 값을 쓰므로, 새 mode를 추가하면 docs도 같이 바꿉니다.
+# mode가 simulator 비용을 결정합니다.
+# profile 실행과 직접 실행이 같은 값을 쓰므로 새 mode는 양쪽에서 같이 다뤄야 합니다.
 case "$MODE" in
   # 기본 검증은 simulator boot 없이 AppMain 조립과 compile 가능 여부만 봅니다.
   build-for-testing)
     ACTION="build-for-testing"
     DESTINATION="${DESTINATION:-generic/platform=iOS Simulator}"
     ;;
-  # CI 비용을 더 줄여야 할 때는 build mode를 명시해서 더 가볍게 봅니다.
+  # compile 가능 여부만 빠르게 볼 때는 build mode를 명시합니다.
   build)
     ACTION="build"
     DESTINATION="${DESTINATION:-generic/platform=iOS Simulator}"
@@ -83,7 +84,7 @@ case "$MODE" in
     ;;
 esac
 
-# skip flag는 prepare_tuist_workspace가 성공한 뒤에만 안전합니다.
+# skip flag는 validate_ios_profile.sh의 prepare_tuist_workspace가 성공한 뒤에만 안전합니다.
 # workspace가 없으면 하위 script를 단독으로 잘못 실행한 상황이므로 xcodebuild 전에 멈춥니다.
 if [[ "$SKIP_TUIST_PREP" == "1" && ! -d "$EXPECTED_WORKSPACE_PATH" ]]; then
   echo "CLIPY_IOS_SKIP_TUIST_PREP=1 requires an existing workspace: ${WORKSPACE}" >&2
@@ -101,6 +102,7 @@ echo "Validation mode: ${MODE}"
 echo "Using destination: ${DESTINATION}"
 
 # 직접 실행은 Tuist graph를 다시 만들고, profile 안의 하위 실행만 재사용합니다.
+# 이 경계를 지켜야 로컬에서는 오래된 생성물을 보지 않고, CI에서는 같은 workspace를 반복 생성하지 않습니다.
 if [[ "$SKIP_TUIST_PREP" == "1" ]]; then
   echo "Skipping Tuist install/generate."
 else

--- a/scripts/validate_ios_module.sh
+++ b/scripts/validate_ios_module.sh
@@ -4,9 +4,10 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-# 로컬 검증에서 직접 돌릴 iOS module scheme만 열어둡니다.
-# module을 추가하면 Tuist manifest, profile router, 이 whitelist를 같이 바꿉니다.
-# 직접 실행 기본값은 CI 비용을 고려해 build-for-testing입니다. test가 필요하면 env로 명시합니다.
+# profile에서 넘어온 scheme을 baseline script로 넘기는 얇은 문지기입니다.
+# 단독 검증 대상으로 열어둔 iOS scheme만 받고, 나머지는 xcodebuild 전에 실패시킵니다.
+# module을 추가하면 Tuist manifest, profile 선택 기준, label resolver, 허용 scheme 목록을 같이 바꿉니다.
+# 기본값은 CI 비용을 줄이기 위해 build-for-testing입니다. test가 필요하면 mode를 명시합니다.
 SUPPORTED_SCHEMES=(
   "AppMain"
   "CoreDomain"
@@ -43,6 +44,8 @@ is_supported_scheme() {
 }
 
 if [[ "${1:-}" == "--check" ]]; then
+  # profile plan을 만들 때는 --check로 scheme 오타만 먼저 봅니다.
+  # 실제 build는 PLAN 실행 단계에서 같은 script가 다시 맡습니다.
   if [[ "$#" -ne 2 ]]; then
     usage
     exit 2
@@ -58,17 +61,18 @@ if [[ "${1:-}" == "--check" ]]; then
 fi
 
 if [[ "$#" -ne 1 ]]; then
-  # scheme은 추론하지 않습니다. module 단위 검증은 호출자가 명시한 scheme만 실행합니다.
+  # module 검증은 대상을 추론하지 않습니다.
+  # label resolver나 로컬 호출자가 고른 scheme만 실행해야 검증 범위가 흔들리지 않습니다.
   usage
   exit 2
 fi
 
 SCHEME="$1"
 
-# whitelist는 지금 repo에서 단독 검증 대상으로 열어둔 module 목록입니다.
-# Tuist에 scheme이 있어도 이 목록에 없으면 profile router에서 먼저 의도를 정리합니다.
+# Tuist에 scheme이 있어도 이 목록에 없으면 검증 대상으로 열지 않습니다.
+# 새 scheme은 profile 기준과 label resolver 기준까지 정리한 뒤 추가합니다.
 if ! is_supported_scheme "$SCHEME"; then
-  # 잘못된 scheme 이름은 xcodebuild까지 보내지 않고 여기서 바로 멈춥니다.
+  # 잘못된 scheme 이름은 xcodebuild까지 보내지 않고 여기서 멈춥니다.
   echo "Unsupported iOS module scheme: ${SCHEME}" >&2
   usage
   exit 2

--- a/scripts/validate_ios_profile.sh
+++ b/scripts/validate_ios_profile.sh
@@ -7,10 +7,11 @@ cd "$ROOT_DIR"
 PROFILE="${CLIPY_IOS_VALIDATION_PROFILE:-}"
 SCHEMES_RAW="${CLIPY_IOS_VALIDATION_SCHEMES:-}"
 DRY_RUN="${CLIPY_IOS_VALIDATION_DRY_RUN:-0}"
-# 기본값은 simulator를 띄우지 않는 build-for-testing입니다.
-# 실제 test가 필요한 작업만 CLIPY_IOS_VALIDATION_MODE=test를 명시합니다.
+# 기본값은 simulator를 띄우지 않는 build-for-testing입니다. test mode는 필요한 작업에서만 명시합니다.
 export CLIPY_IOS_VALIDATION_MODE="${CLIPY_IOS_VALIDATION_MODE:-build-for-testing}"
 
+# 이 script는 label resolver나 로컬 호출자가 넘긴 profile을 실제 검증 순서로 바꿉니다.
+# dry-run과 실제 실행이 같은 PLAN을 보므로 CI에서 고른 흐름을 로컬에서도 재현합니다.
 usage() {
   cat >&2 <<USAGE
 Usage: CLIPY_IOS_VALIDATION_PROFILE=<profile> $0
@@ -35,15 +36,14 @@ USAGE
 }
 
 if [[ -z "$PROFILE" ]]; then
-  # profile이 없으면 넓은 검증으로 추정하지 않습니다.
-  # 비용이 큰 검증을 실수로 돌릴 수 있어서 바로 멈춥니다.
+  # profile이 없으면 fail-fast로 멈춥니다.
+  # 여기서 넓은 검증으로 추정하면 CI 비용과 실제 검증 범위가 호출자마다 달라집니다.
   echo "CLIPY_IOS_VALIDATION_PROFILE is required." >&2
   usage
   exit 2
 fi
 
-# dry-run에서도 mode 오타는 먼저 잡습니다.
-# 잘못된 plan이 PR이나 CI 설정으로 넘어가는 걸 막기 위해서입니다.
+# dry-run이어도 mode 오타는 먼저 잡습니다. 잘못된 plan이 PR이나 CI 설정에 남으면 재현이 어렵습니다.
 case "$CLIPY_IOS_VALIDATION_MODE" in
   build-for-testing|build|test)
     ;;
@@ -62,8 +62,8 @@ PROJECT_SETUP_SCHEMES=(
   "FeatureSession"
 )
 
-# PLAN은 kind|description|command|arg1|arg2 형태로 쌓습니다.
-# dry-run에 보이는 plan과 실제 실행 plan이 갈라지지 않게 같은 배열을 씁니다.
+# PLAN 배열은 dry-run과 실제 실행이 함께 쓰는 command 목록입니다.
+# 입력을 어떻게 받았든 최종 검증 순서는 이 배열만 봅니다.
 add_script_step() {
   local description="$1"
   local entry="script|${description}"
@@ -77,8 +77,8 @@ add_script_step() {
   PLAN+=("$entry")
 }
 
-# build-script는 첫 실행 직전에 Tuist workspace를 한 번만 만듭니다.
-# 이후 child script는 같은 workspace를 써서 CI에서 generate를 반복하지 않습니다.
+# build가 처음 필요해질 때만 Tuist workspace를 만들고, 같은 profile 안에서는 재사용합니다.
+# module이 여러 개여도 install/generate를 반복하지 않게 하는 비용 절감 경계입니다.
 add_build_step() {
   local description="$1"
   local entry="build-script|${description}"
@@ -100,7 +100,7 @@ add_function_step() {
 }
 
 run_command() {
-  # CI 로그에서 실제로 돈 command를 바로 찾을 수 있게 먼저 출력합니다.
+  # CI 로그에서 실제로 실행한 command를 바로 찾을 수 있게 먼저 찍습니다.
   echo "+ $*"
   "$@"
 }
@@ -138,8 +138,7 @@ read_validation_schemes() {
 check_validation_schemes() {
   local scheme
 
-  # scheme 오타는 Tuist generate 전에 잡습니다.
-  # 실제 build 검증은 아래 plan에서 같은 validate_ios_module.sh가 다시 맡습니다.
+  # scheme 오타는 Tuist generate 전에 잡고, 실제 build는 plan step에서 다시 실행합니다.
   for scheme in "${VALIDATION_SCHEMES[@]}"; do
     "$ROOT_DIR/scripts/validate_ios_module.sh" --check "$scheme"
   done
@@ -179,8 +178,8 @@ add_project_setup_module_steps() {
 }
 
 read_changed_files() {
-  # GitHub API나 label 조회는 PR2에서 붙입니다.
-  # PR1에서는 호출자가 넘긴 changed files만 보고 docs-only 여부를 확인합니다.
+  # GitHub에서는 workflow가, 로컬에서는 사람이 changed files를 넘깁니다.
+  # 여기서는 출처를 따지지 않고 docs-only로 build를 생략해도 되는지만 검사합니다.
   if [[ -n "${CLIPY_IOS_CHANGED_FILES:-}" ]]; then
     printf '%s\n' "$CLIPY_IOS_CHANGED_FILES"
     return
@@ -216,7 +215,7 @@ validate_docs_only_changed_files() {
   local path
 
   # changed files 입력이 없으면 docs-only라고 보지 않습니다.
-  # 첫 구현에서는 자동 diff 분석 대신 명시 입력만 받습니다.
+  # build를 생략하는 profile이라서, 증거가 없을 때 안전한 쪽으로 실패시킵니다.
   changed_files="$(read_changed_files)"
 
   if [[ -z "$changed_files" ]]; then
@@ -232,8 +231,7 @@ validate_docs_only_changed_files() {
   done <<< "$changed_files"
 
   if ((${#invalid_paths[@]} > 0)); then
-    # docs-only로 돌렸지만 코드성 파일이 섞인 경우입니다.
-    # 이때는 더 넓은 profile을 골라 다시 실행합니다.
+    # docs-only로 돌렸지만 코드성 파일이 섞였으므로 더 넓은 profile로 다시 봐야 합니다.
     echo "docs-only profile received non-doc/template paths:" >&2
     printf '  %s\n' "${invalid_paths[@]}" >&2
     exit 1
@@ -246,8 +244,7 @@ validate_workflow_yaml() {
   local workflow_count=0
   local workflow
 
-  # PR1에서는 workflow를 바꾸지 않지만, ci profile을 로컬에서 확인할 수 있게 syntax만 봅니다.
-  # macOS 기본 Ruby YAML parser로 충분해서 dependency를 새로 넣지 않습니다.
+  # workflow 변경은 먼저 YAML 문법만 봅니다. macOS 기본 Ruby parser로 충분해서 dependency를 늘리지 않습니다.
   while IFS= read -r workflow; do
     workflow_count=$((workflow_count + 1))
     ruby --disable-gems -e 'require "yaml"; YAML.load_file(ARGV[0])' "$workflow"
@@ -262,49 +259,50 @@ validate_workflow_yaml() {
 }
 
 prepare_tuist_workspace() {
-  # GitHub fresh runner에는 생성물이 없으므로 build profile에서는 install/generate를 먼저 돌립니다.
-  # 재사용 신호는 이 함수가 성공한 뒤 child process에만 넘깁니다.
+  # GitHub runner에는 생성물이 없으므로 build profile에서는 install/generate를 먼저 돌립니다.
+  # 재사용 flag는 이 함수가 성공한 뒤 같은 profile의 하위 script에만 넘깁니다.
+  # 로컬에서 오래된 workspace를 재사용하는 용도로 쓰지 않습니다.
   echo "Preparing Tuist workspace..."
   mise exec -- tuist install
   mise exec -- tuist generate
 }
 
 plan_for_profile() {
-  # profile은 검증 방식과 비용을 정하고, scheme 입력은 검증 대상을 정합니다.
-  # 새 module을 추가하면 validate_ios_module.sh whitelist와 필요한 docs를 같이 바꿉니다.
+  # profile은 검증 비용과 조합을 정하고, scheme 입력은 실제 대상을 정합니다.
+  # 새 module은 허용 scheme 목록과 label resolver까지 맞춘 뒤 profile에 넣습니다.
   case "$PROFILE" in
     project-setup)
-      # Tuist helper나 manifest 규칙을 건드렸을 때 쓰는 넓은 profile입니다.
-      # 전체 앱 test 대신 AppMain과 현재 공개된 module scheme이 build되는지만 봅니다.
+      # Tuist helper나 manifest 규칙을 건드렸을 때는 module build까지 넓게 봅니다.
       add_script_step "Static Tuist policy" "$ROOT_DIR/scripts/validate_tuist_foundation.sh"
       add_build_step "AppMain baseline" "$ROOT_DIR/scripts/validate_ios_baseline.sh"
       add_project_setup_module_steps
       ;;
     ci)
-      # GitHub label mapping을 붙이기 전까지는 로컬에서 직접 호출하는 CI 성격의 profile입니다.
+      # GitHub Actions나 validation script 변경은 YAML과 AppMain 조립을 같이 봅니다.
       add_script_step "Static Tuist policy" "$ROOT_DIR/scripts/validate_tuist_foundation.sh"
       add_function_step "GitHub workflow YAML syntax" validate_workflow_yaml
       add_build_step "AppMain baseline" "$ROOT_DIR/scripts/validate_ios_baseline.sh"
       ;;
     app-main)
-      # 앱 진입점이나 공통 wiring만 바뀐 경우 AppMain scheme만 확인합니다.
+      # 앱 진입점이나 공통 wiring만 바뀐 경우 AppMain scheme만 봅니다.
       add_build_step "AppMain baseline" "$ROOT_DIR/scripts/validate_ios_baseline.sh"
       ;;
     tuist-foundation)
-      # Tuist manifest 규칙과 generated artifact만 빠르게 보고 싶을 때 씁니다.
+      # Tuist manifest 규칙과 git에 이미 올라간 생성물만 빠르게 봅니다.
       add_script_step "Static Tuist policy" "$ROOT_DIR/scripts/validate_tuist_foundation.sh"
       ;;
     module)
-      # 지정한 module scheme만 확인합니다. AppMain 조립까지 볼 필요가 없을 때 씁니다.
+      # 지정한 module scheme만 봅니다. AppMain 조립까지 필요하면 integration을 씁니다.
       add_module_steps
       ;;
     integration)
-      # 지정한 module scheme과 AppMain 조립을 같이 봅니다.
+      # module 변경이 앱 조립에서 깨지는지 같이 봅니다.
       add_module_steps
       add_build_step "AppMain baseline" "$ROOT_DIR/scripts/validate_ios_baseline.sh"
       ;;
     docs-only)
-      # docs-only는 build를 생략하는 대신 changed files로 코드 변경이 섞였는지 확인합니다.
+      # docs-only는 build를 생략하므로 changed files가 public docs/template 범위인지 먼저 봅니다.
+      # 코드성 파일이 하나라도 섞이면 이 profile을 쓰지 않습니다.
       add_function_step "Docs-only changed files check" validate_docs_only_changed_files
       add_script_step "Tracked generated artifact preflight" "$ROOT_DIR/scripts/validate_tuist_foundation.sh" "--generated-artifacts-only"
       ;;
@@ -324,8 +322,7 @@ print_plan() {
   local index
   local kind
 
-  # dry-run도 실제 실행과 같은 PLAN을 봅니다.
-  # 그래서 build 없이도 어떤 검증이 돌지 먼저 리뷰할 수 있습니다.
+  # dry-run도 같은 PLAN을 보므로 build 없이 실제 검증 순서를 확인할 수 있습니다.
   echo "Validation profile: ${PROFILE}"
   echo "Validation mode: ${CLIPY_IOS_VALIDATION_MODE}"
   if plan_has_build_step; then
@@ -347,8 +344,8 @@ plan_has_build_step() {
   local index
   local kind
 
-  # build step이 하나라도 있으면 Tuist install/generate가 필요합니다.
-  # docs-only처럼 function/script step만 있으면 workspace를 만들지 않습니다.
+  # build step이 없으면 workspace를 만들지 않습니다.
+  # docs-only처럼 build를 생략하는 profile에서 Tuist 비용을 쓰지 않기 위해서입니다.
   for index in "${!PLAN[@]}"; do
     IFS='|' read -r kind _ <<< "${PLAN[$index]}"
     if [[ "$kind" == "build-script" ]]; then
@@ -368,18 +365,18 @@ execute_plan() {
   local command
   local tuist_prepared="0"
 
-  # PLAN 순서대로 실행하되, 첫 build-script 직전에만 Tuist workspace를 만듭니다.
-  # static policy가 실패하면 generate 비용을 쓰기 전에 멈춥니다.
+  # 정적 정책 검사가 실패하면 generate 비용을 쓰기 전에 멈춥니다.
+  # 첫 build-script 직전에만 workspace를 만들고 이후 build step은 같은 profile 안에서 재사용합니다.
   for index in "${!PLAN[@]}"; do
     IFS='|' read -r kind description command arg1 arg2 <<< "${PLAN[$index]}"
     echo "==> ${description}"
     if [[ "$kind" == "function" ]]; then
-      # function step은 현재 shell 함수로 실행합니다. docs-only나 yaml syntax처럼 별도 script가 필요 없는 검증입니다.
+      # function step은 docs-only나 YAML syntax처럼 별도 script가 필요 없는 검사만 둡니다.
       "$command"
     else
       if [[ "$kind" == "build-script" && "$tuist_prepared" != "1" ]]; then
         prepare_tuist_workspace
-        # 이 flag는 방금 만든 workspace를 하위 검증에서만 다시 쓰게 하는 내부 신호입니다.
+        # 방금 만든 workspace를 같은 profile 안에서만 재사용하게 하는 내부 신호입니다.
         export CLIPY_IOS_SKIP_TUIST_PREP=1
         tuist_prepared="1"
       fi


### PR DESCRIPTION
  ## 무엇을 바꿨나요?

  PR label을 iOS validation profile로 바꾸는 resolver를 추가하고, iOS Baseline workflow가 그 결과로 검증 스크립트를 실행하도록 연
  결했습니다.

  ## 왜 바꿨나요?

  PR마다 같은 iOS 검증을 전부 돌리면 CI 시간이 길어지고, 반대로 사람이 수동으로 줄이면 검증 범위가 좁아질 위험이 있습니다.
  이번 작업은 PR label 분류를 기준으로 `docs-only`, `app-main`, `integration`, `ci`, `project-setup` 같은 profile을 고르고,
  resolver와 실제 validation script가 같은 기준으로 움직이게 만드는 작업입니다.

  ## 변경 범위

  - PR label을 validation profile로 바꾸는 resolver 추가
  - iOS Baseline workflow에 PR labels, changed files, manual dispatch 연결
  - `docs-only`, `ci`, module AREA별 라우팅 기준 추가
  - validation script 주석과 `Docs/Open/SETUP.md` 사용법 보강

  ```mermaid
  flowchart TD
      A[GitHub PR labels] --> B[iOS Baseline workflow]
      C[PR changed files] --> B

      B --> D[Collect labels and changed files]
      D --> E[resolve_ios_validation_from_labels.sh]

      E --> F{Resolve validation route}

      F -->|"TYPE Docs + docs/template only"| G[profile: docs-only]
      F -->|"AREA CI"| H[profile: ci]
      F -->|"AREA Project Setup"| I[profile: project-setup]
      F -->|"AREA AppMain"| J[profile: app-main]
      F -->|"module AREA"| K[profile: integration + scheme]

    G --> L[Export profile / schemes / changed files]
    H --> L
    I --> L
    J --> L
    K --> L

    L --> M[validate_ios_profile.sh dry-run]
    M --> N[validate_ios_profile.sh]
    N --> O[Run selected validation command]
  ```

PR label 조합 | resolver 판단 | 실제 라우팅
-- | -- | --
TYPE \\| Docs + Docs / docs/template만 변경 | docs-only 허용 | 문서 범위만 확인
TYPE \\| Docs + 코드 / 스크립트 파일 변경 | reject | build 생략으로 숨기지 않음
AREA \\| CI 포함 | ci 우선 | CI 관련 검증
AREA \\| Project Setup | project-setup | Tuist / project setup 검증
AREA \\| AppMain | app-main | AppMain 조립 확인
module AREA | integration | module 단독이 아니라 AppMain 조립까지 확인

  ## 제외한 범위

  - 새 label 체계를 만들지는 않았습니다.
  - GitHub Actions 외부의 별도 CI 서비스 설정은 바꾸지 않았습니다.
  - validation script의 실제 Tuist build 범위를 크게 늘리지는 않았습니다.

  ## 확인한 내용

  - [x] ./scripts/resolve_ios_validation_from_labels.sh 확인
  - [x] ./scripts/validate_ios_profile.sh 확인
  - [x] ./scripts/validate_ios_module.sh 확인
  - [x] ./scripts/validate_ios_baseline.sh 확인
  - [x] ./scripts/validate_tuist_foundation.sh 확인
  - [x] 생성된 .xcodeproj, .xcworkspace, Derived/ 미포함 확인
  - [x] Resolver smoke Test 진행
       - TYPE | Refactor + AREA | FeatureSession → integration / FeatureSession
       - TYPE | Docs + AREA | Docs + AREA | AppMain → reject
       - docs-only + scripts/validate_ios_profile.sh 변경 → reject

  ## 테스트와 문서

  Docs/Open/SETUP.md에 label mapping과 local dry-run 사용법을 정리했습니다.
  이전 full local validation에서는 아래 profile이 통과했습니다.
  - app-main
  - module
  - integration
  - ci
  - project-setup
  - project-setup test mode

  이번 마지막 커밋 이후에는 CI wiring과 resolver 정책이 바뀐 부분을 중심으로 fast validation만 다시 확인했습니다.
  - `TYPE | ...` label은 정확히 1개만 허용합니다.
  - `AREA | ...` label은 여러 개를 허용하지만, `AREA | CI`, `AREA | Project Setup`, module AREA 순서로 profile을 고릅니다.
  - label이 없거나 지원하지 않는 label 조합이면 추정하지 않고 실패합니다.

  ## 리뷰어가 특히 봐야 할 부분

  - AREA | CI가 섞였을 때 ci profile을 우선하는 기준이 적절한지 봐주세요.
  - module AREA를 CI에서 module 단독이 아니라 integration으로 보내는 판단이 맞는지 봐주세요.
  - docs-only가 public docs/template만 허용하는 기준이 너무 좁거나 넓지 않은지 봐주세요.
  - Docs/Open/SETUP.md의 label mapping이 실제 resolver 기준과 다르게 읽히는 부분이 없는지 봐주세요.

  ## 관련 이슈

  Closes #19
  Related: CLIPY-92
