### PR TITLE
[CLIPY-34] Session 초기 Peek 렌더링 연결

### DIFF
--- a/Modules/FeatureSession/Sources/SessionBottomSheet/SessionBottomSheetPolicy.swift
+++ b/Modules/FeatureSession/Sources/SessionBottomSheet/SessionBottomSheetPolicy.swift
@@ -236,6 +236,18 @@ struct SessionBottomSheetPolicy: Equatable {
         )
     }
 
+    /// 브라우저가 보이는 minimized/peek 상태에서만 뒤로/앞으로/새로고침 row를 보여줍니다.
+    func isBrowserControlRowVisible(for state: SessionBottomSheetState) -> Bool {
+        switch state {
+        case .hidden:
+            return false
+        case .minimized, .peek:
+            return true
+        case .expanded:
+            return false
+        }
+    }
+
     private enum DragDirection {
         case upward
         case downward

--- a/Modules/FeatureSession/Sources/SessionBottomSheet/SessionBottomSheetView.swift
+++ b/Modules/FeatureSession/Sources/SessionBottomSheet/SessionBottomSheetView.swift
@@ -29,6 +29,12 @@ final class SessionBottomSheetView: UIView {
 
     private let grabberHitAreaView = UIView()
     private let grabberView = UIView()
+    private let browserControlRowStackView = UIStackView()
+    private let previousButton = UIButton(type: .system)
+    private let nextButton = UIButton(type: .system)
+    private let urlContainerView = UIView()
+    private let urlLabel = UILabel()
+    private let refreshButton = UIButton(type: .system)
     private let peekTitleLabel = UILabel()
     private let peekDescriptionLabel = UILabel()
     private let peekContentStackView = UIStackView()
@@ -61,10 +67,16 @@ final class SessionBottomSheetView: UIView {
 
     private func configureHierarchy() {
         addSubview(grabberHitAreaView)
+        addSubview(browserControlRowStackView)
         addSubview(peekContentStackView)
         addSubview(expandedContentStackView)
 
         grabberHitAreaView.addSubview(grabberView)
+        browserControlRowStackView.addArrangedSubview(previousButton)
+        browserControlRowStackView.addArrangedSubview(nextButton)
+        browserControlRowStackView.addArrangedSubview(urlContainerView)
+        browserControlRowStackView.addArrangedSubview(refreshButton)
+        urlContainerView.addSubview(urlLabel)
         peekContentStackView.addArrangedSubview(peekTitleLabel)
         peekContentStackView.addArrangedSubview(peekDescriptionLabel)
         expandedContentStackView.addArrangedSubview(expandedTitleLabel)
@@ -83,6 +95,29 @@ final class SessionBottomSheetView: UIView {
         grabberView.backgroundColor = .tertiaryLabel
         grabberView.layer.cornerRadius = Layout.grabberHeight / 2
 
+        browserControlRowStackView.axis = .horizontal
+        browserControlRowStackView.alignment = .center
+        browserControlRowStackView.spacing = 8
+        browserControlRowStackView.layoutMargins = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
+        browserControlRowStackView.isLayoutMarginsRelativeArrangement = true
+
+        previousButton.setTitle("‹", for: .normal)
+        previousButton.titleLabel?.font = .preferredFont(forTextStyle: .title2)
+
+        nextButton.setTitle("›", for: .normal)
+        nextButton.titleLabel?.font = .preferredFont(forTextStyle: .title2)
+
+        urlContainerView.backgroundColor = .tertiarySystemBackground
+        urlContainerView.layer.cornerRadius = 12
+
+        urlLabel.text = "Search or enter URL"
+        urlLabel.font = .preferredFont(forTextStyle: .subheadline)
+        urlLabel.textColor = .secondaryLabel
+        urlLabel.lineBreakMode = .byTruncatingMiddle
+
+        refreshButton.setTitle("↻", for: .normal)
+        refreshButton.titleLabel?.font = .preferredFont(forTextStyle: .title3)
+
         [peekContentStackView, expandedContentStackView].forEach {
             $0.axis = .vertical
             $0.alignment = .fill
@@ -91,11 +126,11 @@ final class SessionBottomSheetView: UIView {
             $0.isLayoutMarginsRelativeArrangement = true
         }
 
-        peekTitleLabel.text = "URL Bar"
+        peekTitleLabel.text = "No items yet"
         peekTitleLabel.font = .preferredFont(forTextStyle: .headline)
         peekTitleLabel.textColor = .label
 
-        peekDescriptionLabel.text = "Preview placeholder"
+        peekDescriptionLabel.text = "Add an item from the Top Bar to start comparing."
         peekDescriptionLabel.font = .preferredFont(forTextStyle: .subheadline)
         peekDescriptionLabel.textColor = .secondaryLabel
         peekDescriptionLabel.numberOfLines = 0
@@ -110,6 +145,12 @@ final class SessionBottomSheetView: UIView {
         expandedDescriptionLabel.numberOfLines = 0
 
         accessibilityIdentifier = "sessionBottomSheet"
+        browserControlRowStackView.accessibilityIdentifier = "sessionBottomSheet.browserControls"
+        previousButton.accessibilityIdentifier = "sessionBottomSheet.browserControls.previous"
+        nextButton.accessibilityIdentifier = "sessionBottomSheet.browserControls.next"
+        urlLabel.accessibilityIdentifier = "sessionBottomSheet.browserControls.url"
+        refreshButton.accessibilityIdentifier = "sessionBottomSheet.browserControls.refresh"
+        peekContentStackView.accessibilityIdentifier = "sessionBottomSheet.peekEmptyState"
     }
 
     private func configureGesture() {
@@ -120,6 +161,9 @@ final class SessionBottomSheetView: UIView {
     private func configureLayout() {
         grabberHitAreaView.translatesAutoresizingMaskIntoConstraints = false
         grabberView.translatesAutoresizingMaskIntoConstraints = false
+        browserControlRowStackView.translatesAutoresizingMaskIntoConstraints = false
+        urlContainerView.translatesAutoresizingMaskIntoConstraints = false
+        urlLabel.translatesAutoresizingMaskIntoConstraints = false
         peekContentStackView.translatesAutoresizingMaskIntoConstraints = false
         expandedContentStackView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -134,7 +178,17 @@ final class SessionBottomSheetView: UIView {
             grabberView.widthAnchor.constraint(equalToConstant: Layout.grabberWidth),
             grabberView.heightAnchor.constraint(equalToConstant: Layout.grabberHeight),
 
-            peekContentStackView.topAnchor.constraint(equalTo: grabberHitAreaView.bottomAnchor, constant: 8),
+            browserControlRowStackView.topAnchor.constraint(equalTo: grabberHitAreaView.bottomAnchor, constant: 4),
+            browserControlRowStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            browserControlRowStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+            urlContainerView.heightAnchor.constraint(equalToConstant: 36),
+            urlLabel.topAnchor.constraint(equalTo: urlContainerView.topAnchor, constant: 8),
+            urlLabel.leadingAnchor.constraint(equalTo: urlContainerView.leadingAnchor, constant: 12),
+            urlLabel.trailingAnchor.constraint(equalTo: urlContainerView.trailingAnchor, constant: -12),
+            urlLabel.bottomAnchor.constraint(equalTo: urlContainerView.bottomAnchor, constant: -8),
+
+            peekContentStackView.topAnchor.constraint(equalTo: browserControlRowStackView.bottomAnchor, constant: 12),
             peekContentStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
             peekContentStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
 
@@ -219,9 +273,10 @@ extension SessionBottomSheetView {
         }
     }
 
-    /// ViewModel state를 sheet snap 위치와 content alpha로 렌더링합니다.
+    /// ViewModel state를 sheet 위치와 browser control row 노출 상태로 렌더링합니다.
     func render(state: SessionBottomSheetState, animated: Bool) {
         renderedState = state
+        browserControlRowStackView.isHidden = !policy.isBrowserControlRowVisible(for: state)
         setOffset(policy.offset(for: state, availableHeight: bounds.height), animated: animated)
     }
 

--- a/Modules/FeatureSession/Sources/SessionView/SessionTopBarView.swift
+++ b/Modules/FeatureSession/Sources/SessionView/SessionTopBarView.swift
@@ -1,0 +1,132 @@
+//
+//  SessionTopBarView.swift
+//  Clipy
+//
+//  Created by 박민서 on 6/24/26.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+
+/// Session에서 Home, 제목, item 추가, 접기/펼치기를 담는 상단 floating bar입니다.
+final class SessionTopBarView: UIView {
+    private enum Layout {
+        static let height: CGFloat = 56
+        static let horizontalInset: CGFloat = 16
+        static let itemSpacing: CGFloat = 12
+        static let cornerRadius: CGFloat = 18
+    }
+
+    fileprivate let homeButton = UIButton(type: .system)
+    private let titleLabel = UILabel()
+    private let addItemButton = UIButton(type: .system)
+    private let toggleButton = UIButton(type: .system)
+    private let contentStackView = UIStackView()
+    private var renderedState: SessionTopBarState = .unfolded
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureHierarchy()
+        configureStyle()
+        configureLayout()
+        render(state: renderedState)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    private func configureHierarchy() {
+        addSubview(contentStackView)
+
+        contentStackView.addArrangedSubview(homeButton)
+        contentStackView.addArrangedSubview(titleLabel)
+        contentStackView.addArrangedSubview(addItemButton)
+        contentStackView.addArrangedSubview(toggleButton)
+    }
+
+    private func configureStyle() {
+        backgroundColor = .secondarySystemBackground
+        layer.cornerRadius = Layout.cornerRadius
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.08
+        layer.shadowRadius = 10
+        layer.shadowOffset = CGSize(width: 0, height: 4)
+
+        contentStackView.axis = .horizontal
+        contentStackView.alignment = .center
+        contentStackView.spacing = Layout.itemSpacing
+        contentStackView.layoutMargins = UIEdgeInsets(
+            top: 0,
+            left: Layout.horizontalInset,
+            bottom: 0,
+            right: Layout.horizontalInset
+        )
+        contentStackView.isLayoutMarginsRelativeArrangement = true
+
+        homeButton.setTitle("Home", for: .normal)
+        homeButton.titleLabel?.font = .preferredFont(forTextStyle: .headline)
+
+        titleLabel.text = "Session"
+        titleLabel.font = .preferredFont(forTextStyle: .headline)
+        titleLabel.textAlignment = .center
+        titleLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        addItemButton.setTitle("Add Item", for: .normal)
+        addItemButton.titleLabel?.font = .preferredFont(forTextStyle: .headline)
+
+        toggleButton.titleLabel?.font = .preferredFont(forTextStyle: .headline)
+
+        accessibilityIdentifier = "sessionTopBar"
+        homeButton.accessibilityIdentifier = "sessionTopBar.home"
+        titleLabel.accessibilityIdentifier = "sessionTopBar.title"
+        addItemButton.accessibilityIdentifier = "sessionTopBar.addItem"
+        toggleButton.accessibilityIdentifier = "sessionTopBar.toggle"
+    }
+
+    private func configureLayout() {
+        contentStackView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(equalToConstant: Layout.height),
+
+            contentStackView.topAnchor.constraint(equalTo: topAnchor),
+            contentStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            contentStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            contentStackView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+}
+
+// MARK: - Interface
+
+extension SessionTopBarView {
+    /// 접힘 상태에 맞춰 버튼 노출과 toggle title을 맞춥니다.
+    func render(state: SessionTopBarState) {
+        renderedState = state
+
+        switch state {
+        case .folded:
+            homeButton.isHidden = true
+            titleLabel.isHidden = true
+            addItemButton.isHidden = true
+            toggleButton.setTitle("Expand", for: .normal)
+        case .unfolded:
+            homeButton.isHidden = false
+            titleLabel.isHidden = false
+            addItemButton.isHidden = false
+            toggleButton.setTitle("Collapse", for: .normal)
+        }
+    }
+}
+
+// MARK: - Reactive
+
+extension Reactive where Base: SessionTopBarView {
+    var homeTap: ControlEvent<Void> {
+        base.homeButton.rx.tap
+    }
+}

--- a/Modules/FeatureSession/Sources/SessionView/SessionView.swift
+++ b/Modules/FeatureSession/Sources/SessionView/SessionView.swift
@@ -70,6 +70,11 @@ extension SessionView {
         browserView.load(url: url)
     }
 
+    /// 새 Session의 첫 화면에서 Top Bar가 어떤 모습으로 시작할지 반영합니다.
+    func render(chromeState: SessionInitialChromeState) {
+        topBarView.render(state: chromeState.topBarState)
+    }
+
     /// Bottom Sheet ViewModel state를 내부 sheet component에 전달합니다.
     func render(bottomSheetState: SessionBottomSheetState, animated: Bool) {
         bottomSheetView.render(state: bottomSheetState, animated: animated)

--- a/Modules/FeatureSession/Sources/SessionView/SessionView.swift
+++ b/Modules/FeatureSession/Sources/SessionView/SessionView.swift
@@ -11,13 +11,11 @@ import UIKit
 import RxCocoa
 import RxSwift
 
-/// Session 화면의 header와 browser 영역을 배치하는 root view입니다.
+/// Session WebView 위에 Top Bar와 Bottom Sheet를 겹쳐 배치하는 root view입니다.
 final class SessionView: UIView {
-    fileprivate let homeButton = UIButton(type: .system)
+    fileprivate let topBarView = SessionTopBarView()
     private let browserView = SessionWebView()
     fileprivate let bottomSheetView = SessionBottomSheetView()
-    private let headerView = UIView()
-    private let titleLabel = UILabel()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -32,56 +30,34 @@ final class SessionView: UIView {
     }
 
     private func configureHierarchy() {
-        addSubview(headerView)
         addSubview(browserView)
+        addSubview(topBarView)
         addSubview(bottomSheetView)
-
-        headerView.addSubview(homeButton)
-        headerView.addSubview(titleLabel)
     }
 
     private func configureStyle() {
         backgroundColor = .systemBackground
-        headerView.backgroundColor = .systemBackground
-
-        homeButton.setTitle("Home", for: .normal)
-        homeButton.titleLabel?.font = .preferredFont(forTextStyle: .headline)
-
-        titleLabel.text = "Session"
-        titleLabel.font = .preferredFont(forTextStyle: .headline)
-        titleLabel.textAlignment = .center
     }
 
     private func configureLayout() {
-        headerView.translatesAutoresizingMaskIntoConstraints = false
+        topBarView.translatesAutoresizingMaskIntoConstraints = false
         browserView.translatesAutoresizingMaskIntoConstraints = false
         bottomSheetView.translatesAutoresizingMaskIntoConstraints = false
-        homeButton.translatesAutoresizingMaskIntoConstraints = false
-        titleLabel.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
-            headerView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
-            headerView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            headerView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            headerView.heightAnchor.constraint(equalToConstant: 56),
-
-            browserView.topAnchor.constraint(equalTo: headerView.bottomAnchor),
+            browserView.topAnchor.constraint(equalTo: topAnchor),
             browserView.leadingAnchor.constraint(equalTo: leadingAnchor),
             browserView.trailingAnchor.constraint(equalTo: trailingAnchor),
             browserView.bottomAnchor.constraint(equalTo: bottomAnchor),
 
+            topBarView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 12),
+            topBarView.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+            topBarView.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+
             bottomSheetView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
             bottomSheetView.leadingAnchor.constraint(equalTo: leadingAnchor),
             bottomSheetView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            bottomSheetView.bottomAnchor.constraint(equalTo: bottomAnchor),
-
-            homeButton.leadingAnchor.constraint(equalTo: headerView.layoutMarginsGuide.leadingAnchor),
-            homeButton.centerYAnchor.constraint(equalTo: headerView.centerYAnchor),
-
-            titleLabel.centerXAnchor.constraint(equalTo: headerView.centerXAnchor),
-            titleLabel.centerYAnchor.constraint(equalTo: headerView.centerYAnchor),
-            titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: homeButton.trailingAnchor, constant: 12),
-            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: headerView.layoutMarginsGuide.trailingAnchor)
+            bottomSheetView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
     }
 }
@@ -103,9 +79,9 @@ extension SessionView {
 // MARK: - Reactive
 
 extension Reactive where Base: SessionView {
-    /// Home button tap을 화면 종료 input으로 엽니다.
+    /// Top Bar의 Home tap을 화면 종료 input으로 엽니다.
     var homeTap: ControlEvent<Void> {
-        base.homeButton.rx.tap
+        base.topBarView.rx.homeTap
     }
 
     /// Bottom Sheet grabber drag 종료 action을 ViewModel input으로 엽니다.

--- a/Modules/FeatureSession/Sources/SessionView/SessionViewController.swift
+++ b/Modules/FeatureSession/Sources/SessionView/SessionViewController.swift
@@ -76,6 +76,12 @@ final class SessionViewController: UIViewController {
             }
             .disposed(by: disposeBag)
 
+        output.initialChromeState
+            .emit(with: self) { owner, chromeState in
+                owner.rootView.render(chromeState: chromeState)
+            }
+            .disposed(by: disposeBag)
+
         output.route
             .emit(with: self) { owner, route in
                 owner.handle(route: route)

--- a/Modules/FeatureSession/Sources/SessionView/SessionViewModel.swift
+++ b/Modules/FeatureSession/Sources/SessionView/SessionViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+
 import RxCocoa
 
 /// Session 화면에서 사용자가 의도한 화면 이동을 표현합니다.
@@ -20,7 +21,16 @@ enum SessionTopBarState: Equatable {
     case unfolded
 }
 
-/// Session 진입 입력을 WebView load command와 화면 route로 바꿉니다.
+/// 새 Session의 첫 렌더링에 필요한 상단 chrome 상태입니다.
+struct SessionInitialChromeState: Equatable {
+    let topBarState: SessionTopBarState
+
+    static let newSession = SessionInitialChromeState(
+        topBarState: .unfolded
+    )
+}
+
+/// Session 진입 event와 home tap을 초기 URL load, 초기 chrome 상태, route로 바꿉니다.
 final class SessionViewModel {
     struct Input {
         /// 화면 최초 진입 시 초기 URL load를 시작하는 lifecycle event입니다.
@@ -32,6 +42,8 @@ final class SessionViewModel {
     struct Output {
         /// Browser가 처음 load해야 하는 URL command입니다.
         let initialLoadURL: Signal<URL>
+        /// 새 Session 진입 직후 Top Bar가 읽는 초기 chrome 상태입니다.
+        let initialChromeState: Signal<SessionInitialChromeState>
         /// ViewController가 처리해야 하는 화면 이동 의도입니다.
         let route: Signal<SessionRoute>
     }
@@ -48,11 +60,15 @@ final class SessionViewModel {
                 initialURL
             }
 
+        let initialChromeState = input.viewDidLoad
+            .map { SessionInitialChromeState.newSession }
+
         let route = input.homeTap
             .map { SessionRoute.home }
 
         return Output(
             initialLoadURL: initialLoadURL,
+            initialChromeState: initialChromeState,
             route: route
         )
     }

--- a/Modules/FeatureSession/Sources/SessionView/SessionViewModel.swift
+++ b/Modules/FeatureSession/Sources/SessionView/SessionViewModel.swift
@@ -14,6 +14,12 @@ enum SessionRoute: Equatable {
     case home
 }
 
+/// 상단 floating bar를 전체로 보여줄지, 접어서 보여줄지 나타냅니다.
+enum SessionTopBarState: Equatable {
+    case folded
+    case unfolded
+}
+
 /// Session 진입 입력을 WebView load command와 화면 route로 바꿉니다.
 final class SessionViewModel {
     struct Input {

--- a/Modules/FeatureSession/Tests/SessionBottomSheet/SessionBottomSheetPolicyTests.swift
+++ b/Modules/FeatureSession/Tests/SessionBottomSheet/SessionBottomSheetPolicyTests.swift
@@ -154,6 +154,15 @@ final class SessionBottomSheetPolicyTests: XCTestCase {
         XCTAssertEqual(expandedContent, .init(peek: 0, expanded: 1))
     }
 
+    func test_browserControlRowVisibility_showsOnlyWhileBrowsingChromeCanStayVisible() {
+        let sut = SessionBottomSheetPolicy.standard
+
+        XCTAssertFalse(sut.isBrowserControlRowVisible(for: .hidden))
+        XCTAssertTrue(sut.isBrowserControlRowVisible(for: .minimized))
+        XCTAssertTrue(sut.isBrowserControlRowVisible(for: .peek))
+        XCTAssertFalse(sut.isBrowserControlRowVisible(for: .expanded))
+    }
+
     private func dragEnded(
         endVisibleHeight: CGFloat,
         translationY: CGFloat,

--- a/Modules/FeatureSession/Tests/SessionView/SessionViewModelTests.swift
+++ b/Modules/FeatureSession/Tests/SessionView/SessionViewModelTests.swift
@@ -62,6 +62,20 @@ final class SessionViewModelTests: XCTestCase {
         XCTAssertTrue(loadedURLs.isEmpty)
     }
 
+    func test_viewDidLoad_emitsUnfoldedTopBarState_forNewSessionEntry() {
+        let viewDidLoadRelay = PublishRelay<Void>()
+        let output = makeOutput(viewDidLoad: viewDidLoadRelay.asSignal())
+        var chromeStates: [SessionInitialChromeState] = []
+
+        output.initialChromeState
+            .emit(onNext: { chromeStates.append($0) })
+            .disposed(by: disposeBag)
+
+        viewDidLoadRelay.accept(())
+
+        XCTAssertEqual(chromeStates, [.newSession])
+    }
+
     func test_homeTap_emitsHomeRoute_forExplicitSessionExit() {
         let homeTapRelay = PublishRelay<Void>()
         let output = makeOutput(homeTap: homeTapRelay.asSignal())


### PR DESCRIPTION
## 무엇을 바꿨나요?

세션 진입 직후 chrome UI가 Top Bar와 Bottom Sheet 상태를 같이 따라가도록 연결했습니다. 기존 헤더는 신규 Top Bar로 교체했고, Peek Bottom Sheet에는 browser control row와 빈 상태 문구를 추가했습니다.

## 왜 바꿨나요?

새 세션에 들어왔을 때 사용자가 현재 세션 상태와 탐색 조작 위치를 바로 볼 수 있어야 합니다. 이번 PR에서는 초기 렌더링에 필요한 UI 상태만 연결하고, Peek 상태 관리 책임은 기존 `SessionBottomSheetViewModel`에 그대로 두었습니다.

## 변경 범위

- 기존 세션 헤더를 floating Top Bar로 교체했습니다.
- 새 세션 진입 시 Top Bar가 unfolded로 시작하도록 연결했습니다.
- Peek Bottom Sheet에 prev/next/URL/refresh row와 empty state 문구를 추가했습니다.
- Expanded 상태에서는 browser control row를 숨기도록 정책 헬퍼와 테스트를 추가했습니다.

## 제외한 범위

- Bottom Sheet 초기 Peek 상태 관리 책임은 바꾸지 않았습니다.
- 웹뷰 스크롤 기반 Top Bar fold/unfold 전이는 포함하지 않았습니다.
- browser control의 실제 WebView command 연결은 포함하지 않았습니다.

## 확인한 내용

- [x] `./scripts/validate_ios_baseline.sh` 또는 필요한 경우 `CLIPY_IOS_VALIDATION_MODE=test ./scripts/validate_ios_baseline.sh` 확인
  - `CLIPY_IOS_VALIDATION_PROFILE=module CLIPY_IOS_VALIDATION_SCHEMES=FeatureSession ./scripts/validate_ios_profile.sh`
  - `CLIPY_IOS_VALIDATION_PROFILE=module CLIPY_IOS_VALIDATION_SCHEMES=FeatureSession CLIPY_IOS_VALIDATION_MODE=test ./scripts/validate_ios_profile.sh`
- [x] 생성된 `.xcodeproj`, `.xcworkspace`, `Derived/` 미포함 확인

## 테스트와 문서

View hierarchy 대신 ViewModel output과 Bottom Sheet 정책을 각각 검증했습니다. 초기 Top Bar 상태와 Expanded에서 browser control row를 숨기는 규칙을 확인합니다.

## 관련 이슈

Closes #23  
Related: CLIPY-34, CLIPY-52, CLIPY-62
