### PR TITLE
[CLIPY-72] WebView root scroll 입력 분리

### DIFF
--- a/Modules/FeatureSession/Sources/SessionWeb/RootScroll/SessionWebRootScrollAdapter.swift
+++ b/Modules/FeatureSession/Sources/SessionWeb/RootScroll/SessionWebRootScrollAdapter.swift
@@ -1,0 +1,71 @@
+//
+//  SessionWebRootScrollAdapter.swift
+//  Clipy
+//
+//  Created by 박민서 on 7/5/26.
+//
+
+import CoreGraphics
+
+/// UIScrollViewDelegate callback 순서를 chrome reducer가 읽을 수 있는 root scroll input으로 바꿉니다.
+final class SessionWebRootScrollAdapter {
+    private var isDragging = false
+    private var pendingDragEndContentVelocityY: CGFloat?
+
+    func beginDragging(snapshot: SessionWebRootScrollSnapshot) -> SessionWebRootScrollInput {
+        isDragging = true
+        pendingDragEndContentVelocityY = nil
+        return .dragBegan(snapshot)
+    }
+
+    func scrollInput(snapshot: SessionWebRootScrollSnapshot) -> SessionWebRootScrollInput {
+        guard isDragging else {
+            return .externalScroll(snapshot)
+        }
+
+        return .dragged(snapshot)
+    }
+
+    func prepareDragEnd(
+        releaseVelocityY: CGFloat,
+        targetOffsetY: CGFloat,
+        currentOffsetY: CGFloat
+    ) {
+        pendingDragEndContentVelocityY = Self.contentVelocityY(
+            releaseVelocityY: releaseVelocityY,
+            targetOffsetY: targetOffsetY,
+            currentOffsetY: currentOffsetY
+        )
+    }
+
+    func endDragging(
+        snapshot: SessionWebRootScrollSnapshot
+    ) -> SessionWebRootScrollInput {
+        defer {
+            isDragging = false
+            pendingDragEndContentVelocityY = nil
+        }
+
+        return .dragEnded(
+            SessionWebRootDragEndContext(
+                snapshot: snapshot,
+                velocityY: pendingDragEndContentVelocityY ?? 0
+            )
+        )
+    }
+
+    /// 손을 뗀 순간에는 UIKit velocity 부호보다 예상 target offset 차이가 page 방향을 더 직접적으로 보여줍니다.
+    static func contentVelocityY(
+        releaseVelocityY: CGFloat,
+        targetOffsetY: CGFloat,
+        currentOffsetY: CGFloat
+    ) -> CGFloat {
+        let projectedDeltaY = targetOffsetY - currentOffsetY
+        guard projectedDeltaY != 0 else {
+            return 0
+        }
+
+        let speed = abs(releaseVelocityY)
+        return projectedDeltaY > 0 ? speed : -speed
+    }
+}

--- a/Modules/FeatureSession/Sources/SessionWeb/RootScroll/SessionWebRootScrollInput.swift
+++ b/Modules/FeatureSession/Sources/SessionWeb/RootScroll/SessionWebRootScrollInput.swift
@@ -1,0 +1,33 @@
+//
+//  SessionWebRootScrollInput.swift
+//  Clipy
+//
+//  Created by 박민서 on 7/5/26.
+//
+
+import CoreGraphics
+
+/// UIScrollView 전체를 넘기지 않고 chrome 전이에 필요한 위치와 page 크기만 남긴 값입니다.
+struct SessionWebRootScrollSnapshot: Equatable {
+    let offsetY: CGFloat
+    let contentHeight: CGFloat
+    let viewportHeight: CGFloat
+    let adjustedContentInsetTop: CGFloat
+    let adjustedContentInsetBottom: CGFloat
+}
+
+/// 사용자가 WebView drag를 끝낸 순간 reducer가 한 번만 flick를 판단할 때 쓰는 입력입니다.
+struct SessionWebRootDragEndContext: Equatable {
+    let snapshot: SessionWebRootScrollSnapshot
+    /// content offset 기준 속도입니다. 양수면 page down, 음수면 page up 방향입니다.
+    let velocityY: CGFloat
+}
+
+/// WebKit/UIScrollView callback을 FeatureSession 안에서 다루기 좋게 바꾼 lifecycle input입니다.
+enum SessionWebRootScrollInput: Equatable {
+    case dragBegan(SessionWebRootScrollSnapshot)
+    case dragged(SessionWebRootScrollSnapshot)
+    case dragEnded(SessionWebRootDragEndContext)
+    case decelerated(SessionWebRootScrollSnapshot)
+    case externalScroll(SessionWebRootScrollSnapshot)
+}

--- a/Modules/FeatureSession/Sources/SessionWeb/RootScroll/SessionWebRootScrollPolicy.swift
+++ b/Modules/FeatureSession/Sources/SessionWeb/RootScroll/SessionWebRootScrollPolicy.swift
@@ -1,0 +1,89 @@
+//
+//  SessionWebRootScrollPolicy.swift
+//  Clipy
+//
+//  Created by 박민서 on 7/5/26.
+//
+
+import CoreGraphics
+
+/// Root scroll이 chrome 전환에 쓸 수 있는 방향과 page 조건을 계산합니다.
+struct SessionWebRootScrollPolicy: Equatable {
+    private let dragThreshold: CGFloat
+    private let flickVelocityThreshold: CGFloat
+    private let minimumScrollableViewportRatio: CGFloat
+
+    init(
+        dragThreshold: CGFloat = 12,
+        flickVelocityThreshold: CGFloat = 1_200,
+        minimumScrollableViewportRatio: CGFloat = 0.20
+    ) {
+        self.dragThreshold = dragThreshold
+        self.flickVelocityThreshold = flickVelocityThreshold
+        self.minimumScrollableViewportRatio = minimumScrollableViewportRatio
+    }
+
+    func movement(
+        fromAnchorOffsetY anchorOffsetY: CGFloat,
+        to snapshot: SessionWebRootScrollSnapshot
+    ) -> SessionWebRootScrollMovement? {
+        guard isInsideScrollableBounds(snapshot) else {
+            return nil
+        }
+
+        let deltaY = snapshot.offsetY - anchorOffsetY
+        guard abs(deltaY) >= dragThreshold else {
+            return nil
+        }
+
+        return SessionWebRootScrollMovement(
+            direction: deltaY > 0 ? .down : .up,
+            isEligibleForChromeTransition: isEligibleForChromeTransition(snapshot)
+        )
+    }
+
+    func flickMovement(
+        from context: SessionWebRootDragEndContext
+    ) -> SessionWebRootScrollMovement? {
+        guard isInsideScrollableBounds(context.snapshot),
+              abs(context.velocityY) >= flickVelocityThreshold else {
+            return nil
+        }
+
+        return SessionWebRootScrollMovement(
+            direction: context.velocityY > 0 ? .down : .up,
+            isEligibleForChromeTransition: isEligibleForChromeTransition(context.snapshot)
+        )
+    }
+
+    func isInsideScrollableBounds(_ snapshot: SessionWebRootScrollSnapshot) -> Bool {
+        // rubber-band offset은 실제 page 이동이 아니어서 chrome 전이 신호에서 빼둡니다.
+        let minimumOffsetY = -max(snapshot.adjustedContentInsetTop, 0)
+        let maximumOffsetY = max(
+            minimumOffsetY,
+            max(snapshot.contentHeight, 0) - max(snapshot.viewportHeight, 0) + max(snapshot.adjustedContentInsetBottom, 0)
+        )
+
+        return snapshot.offsetY >= minimumOffsetY && snapshot.offsetY <= maximumOffsetY
+    }
+
+    private func isEligibleForChromeTransition(_ snapshot: SessionWebRootScrollSnapshot) -> Bool {
+        let viewportHeight = max(snapshot.viewportHeight, 0)
+        let scrollableHeight = max(
+            snapshot.contentHeight + snapshot.adjustedContentInsetTop + snapshot.adjustedContentInsetBottom - viewportHeight,
+            0
+        )
+        return scrollableHeight >= viewportHeight * minimumScrollableViewportRatio
+    }
+}
+
+/// Chrome reducer가 presentation 전이를 판단할 때 쓰는 root scroll movement입니다.
+struct SessionWebRootScrollMovement: Equatable {
+    let direction: SessionWebRootScrollDirection
+    let isEligibleForChromeTransition: Bool
+}
+
+enum SessionWebRootScrollDirection: Equatable {
+    case up
+    case down
+}

--- a/Modules/FeatureSession/Sources/SessionWeb/RootScroll/SessionWebView+Scroll.swift
+++ b/Modules/FeatureSession/Sources/SessionWeb/RootScroll/SessionWebView+Scroll.swift
@@ -1,0 +1,49 @@
+//
+//  SessionWebView+Scroll.swift
+//  Clipy
+//
+//  Created by 박민서 on 7/5/26.
+//
+
+import UIKit
+
+extension SessionWebView: UIScrollViewDelegate {
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        beginRootDragging(snapshot: scrollSnapshot(from: scrollView))
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard !scrollView.isDecelerating else {
+            return
+        }
+
+        emitRootDraggingIfNeeded(snapshot: scrollSnapshot(from: scrollView))
+    }
+
+    func scrollViewWillEndDragging(
+        _ scrollView: UIScrollView,
+        withVelocity velocity: CGPoint,
+        targetContentOffset: UnsafeMutablePointer<CGPoint>
+    ) {
+        prepareRootDragEnd(
+            releaseVelocityY: velocity.y,
+            targetOffsetY: targetContentOffset.pointee.y,
+            currentOffsetY: scrollView.contentOffset.y
+        )
+    }
+
+    func scrollViewDidEndDragging(
+        _ scrollView: UIScrollView,
+        willDecelerate _: Bool
+    ) {
+        endRootDragging(snapshot: scrollSnapshot(from: scrollView))
+    }
+
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        emitRootScroll(.decelerated(scrollSnapshot(from: scrollView)))
+    }
+
+    func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+        emitRootScroll(.externalScroll(scrollSnapshot(from: scrollView)))
+    }
+}

--- a/Modules/FeatureSession/Sources/SessionWeb/SessionWebView.swift
+++ b/Modules/FeatureSession/Sources/SessionWeb/SessionWebView.swift
@@ -20,8 +20,10 @@ final class SessionWebView: UIView {
     fileprivate let stateRelay = BehaviorRelay(value: SessionBrowserState.empty)
     /// WebKit navigation 실패를 feature-owned event로 내보내는 relay입니다.
     fileprivate let navigationFailureRelay = PublishRelay<SessionWebNavigationFailure>()
+    fileprivate let rootScrollRelay = PublishRelay<SessionWebRootScrollInput>()
     /// WebKit KVO lifecycle을 SessionWebView 생명주기에 묶어두는 token 목록입니다.
     private var observations: [NSKeyValueObservation] = []
+    private let rootScrollAdapter = SessionWebRootScrollAdapter()
 
     override init(frame: CGRect) {
         webView = WKWebView(frame: .zero)
@@ -40,6 +42,7 @@ final class SessionWebView: UIView {
         backgroundColor = .systemBackground
 
         webView.navigationDelegate = self
+        webView.scrollView.delegate = self
         webView.allowsBackForwardNavigationGestures = true
         webView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -82,6 +85,44 @@ final class SessionWebView: UIView {
     func emitNavigationFailure(_ failure: SessionWebNavigationFailure) {
         navigationFailureRelay.accept(failure)
     }
+
+    func beginRootDragging(snapshot: SessionWebRootScrollSnapshot) {
+        emitRootScroll(rootScrollAdapter.beginDragging(snapshot: snapshot))
+    }
+
+    func emitRootDraggingIfNeeded(snapshot: SessionWebRootScrollSnapshot) {
+        emitRootScroll(rootScrollAdapter.scrollInput(snapshot: snapshot))
+    }
+
+    func prepareRootDragEnd(
+        releaseVelocityY: CGFloat,
+        targetOffsetY: CGFloat,
+        currentOffsetY: CGFloat
+    ) {
+        rootScrollAdapter.prepareDragEnd(
+            releaseVelocityY: releaseVelocityY,
+            targetOffsetY: targetOffsetY,
+            currentOffsetY: currentOffsetY
+        )
+    }
+
+    func endRootDragging(snapshot: SessionWebRootScrollSnapshot) {
+        emitRootScroll(rootScrollAdapter.endDragging(snapshot: snapshot))
+    }
+
+    func emitRootScroll(_ input: SessionWebRootScrollInput) {
+        rootScrollRelay.accept(input)
+    }
+
+    func scrollSnapshot(from scrollView: UIScrollView) -> SessionWebRootScrollSnapshot {
+        SessionWebRootScrollSnapshot(
+            offsetY: scrollView.contentOffset.y,
+            contentHeight: scrollView.contentSize.height,
+            viewportHeight: scrollView.bounds.height,
+            adjustedContentInsetTop: scrollView.adjustedContentInset.top,
+            adjustedContentInsetBottom: scrollView.adjustedContentInset.bottom
+        )
+    }
 }
 
 // MARK: - Interface
@@ -123,5 +164,10 @@ extension Reactive where Base: SessionWebView {
     /// WebKit navigation 실패를 ViewModel이나 ViewController가 처리할 수 있는 event로 제공합니다.
     var navigationFailure: Signal<SessionWebNavigationFailure> {
         base.navigationFailureRelay.asSignal()
+    }
+
+    /// WebView root scroll lifecycle을 chrome reducer input으로 제공합니다.
+    var rootScroll: Signal<SessionWebRootScrollInput> {
+        base.rootScrollRelay.asSignal()
     }
 }

--- a/Modules/FeatureSession/Tests/SessionWeb/RootScroll/SessionWebRootScrollPolicyTests.swift
+++ b/Modules/FeatureSession/Tests/SessionWeb/RootScroll/SessionWebRootScrollPolicyTests.swift
@@ -1,0 +1,106 @@
+//
+//  SessionWebRootScrollPolicyTests.swift
+//  Clipy
+//
+//  Created by 박민서 on 7/5/26.
+//
+
+import CoreGraphics
+import XCTest
+
+@testable import FeatureSession
+
+final class SessionWebRootScrollPolicyTests: XCTestCase {
+    func test_dragMovementBeyondThreshold_returnsDirectionAndEligibility_forScrollableRootPage() {
+        let sut = SessionWebRootScrollPolicy()
+
+        let movement = sut.movement(
+            fromAnchorOffsetY: 20,
+            to: snapshot(offsetY: 60)
+        )
+
+        XCTAssertEqual(movement, .init(direction: .down, isEligibleForChromeTransition: true))
+    }
+
+    func test_smallOffsetChange_returnsNil_forBounceNoise() {
+        let sut = SessionWebRootScrollPolicy()
+
+        let movement = sut.movement(
+            fromAnchorOffsetY: 20,
+            to: snapshot(offsetY: 27)
+        )
+
+        XCTAssertNil(movement)
+    }
+
+    func test_topRubberBand_returnsNil_forOutOfBoundsOffset() {
+        let sut = SessionWebRootScrollPolicy()
+
+        let movement = sut.movement(
+            fromAnchorOffsetY: 4,
+            to: snapshot(offsetY: -18)
+        )
+
+        XCTAssertNil(movement)
+    }
+
+    func test_bottomRubberBand_returnsNil_forOutOfBoundsOffset() {
+        let sut = SessionWebRootScrollPolicy()
+
+        let movement = sut.movement(
+            fromAnchorOffsetY: 380,
+            to: snapshot(offsetY: 430)
+        )
+
+        XCTAssertNil(movement)
+    }
+
+    func test_shortRootPage_returnsIneligibleMovement_forChromeReducerGuard() {
+        let sut = SessionWebRootScrollPolicy()
+
+        let movement = sut.movement(
+            fromAnchorOffsetY: 0,
+            to: snapshot(offsetY: 30, contentHeight: 900)
+        )
+
+        XCTAssertEqual(movement, .init(direction: .down, isEligibleForChromeTransition: false))
+    }
+
+    func test_fastFlickMovement_returnsDirectionOnce_fromDragEndVelocity() {
+        let sut = SessionWebRootScrollPolicy()
+
+        let down = sut.flickMovement(from: dragEnd(offsetY: 4, velocityY: 1_600))
+        let up = sut.flickMovement(from: dragEnd(offsetY: 40, velocityY: -1_600))
+        let slow = sut.flickMovement(from: dragEnd(offsetY: 4, velocityY: 800))
+
+        XCTAssertEqual(down, .init(direction: .down, isEligibleForChromeTransition: true))
+        XCTAssertEqual(up, .init(direction: .up, isEligibleForChromeTransition: true))
+        XCTAssertNil(slow)
+    }
+
+    private func snapshot(
+        offsetY: CGFloat,
+        contentHeight: CGFloat = 1_200,
+        viewportHeight: CGFloat = 800,
+        adjustedContentInsetTop: CGFloat = 0,
+        adjustedContentInsetBottom: CGFloat = 0
+    ) -> SessionWebRootScrollSnapshot {
+        SessionWebRootScrollSnapshot(
+            offsetY: offsetY,
+            contentHeight: contentHeight,
+            viewportHeight: viewportHeight,
+            adjustedContentInsetTop: adjustedContentInsetTop,
+            adjustedContentInsetBottom: adjustedContentInsetBottom
+        )
+    }
+
+    private func dragEnd(
+        offsetY: CGFloat,
+        velocityY: CGFloat
+    ) -> SessionWebRootDragEndContext {
+        SessionWebRootDragEndContext(
+            snapshot: snapshot(offsetY: offsetY),
+            velocityY: velocityY
+        )
+    }
+}

--- a/Modules/FeatureSession/Tests/SessionWeb/RootScroll/SessionWebViewRootScrollAdapterTests.swift
+++ b/Modules/FeatureSession/Tests/SessionWeb/RootScroll/SessionWebViewRootScrollAdapterTests.swift
@@ -1,0 +1,97 @@
+//
+//  SessionWebViewRootScrollAdapterTests.swift
+//  Clipy
+//
+//  Created by 박민서 on 7/5/26.
+//
+
+import CoreGraphics
+import XCTest
+
+@testable import FeatureSession
+
+final class SessionWebViewRootScrollAdapterTests: XCTestCase {
+    func test_releaseVelocityY_usesTargetOffsetDirection_forPageDownFlick() {
+        let velocityY = SessionWebRootScrollAdapter.contentVelocityY(
+            releaseVelocityY: -1_600,
+            targetOffsetY: 140,
+            currentOffsetY: 20
+        )
+
+        XCTAssertEqual(velocityY, 1_600)
+    }
+
+    func test_releaseVelocityY_usesTargetOffsetDirection_forPageUpFlick() {
+        let velocityY = SessionWebRootScrollAdapter.contentVelocityY(
+            releaseVelocityY: 1_600,
+            targetOffsetY: 20,
+            currentOffsetY: 140
+        )
+
+        XCTAssertEqual(velocityY, -1_600)
+    }
+
+    func test_releaseVelocityY_returnsZero_whenProjectedOffsetDoesNotMove() {
+        let velocityY = SessionWebRootScrollAdapter.contentVelocityY(
+            releaseVelocityY: 1_600,
+            targetOffsetY: 40,
+            currentOffsetY: 40
+        )
+
+        XCTAssertEqual(velocityY, 0)
+    }
+
+    func test_endDraggingWithoutPreparedTargetOffset_returnsZeroVelocity_forNoFlickFallback() {
+        let sut = SessionWebRootScrollAdapter()
+        let snapshot = snapshot(offsetY: 20)
+
+        _ = sut.beginDragging(snapshot: snapshot)
+        let input = sut.endDragging(snapshot: snapshot)
+
+        XCTAssertEqual(
+            input,
+            .dragEnded(SessionWebRootDragEndContext(snapshot: snapshot, velocityY: 0))
+        )
+    }
+
+    func test_beginDraggingClearsPreparedVelocity_forInterruptedPreviousDrag() {
+        let sut = SessionWebRootScrollAdapter()
+        let snapshot = snapshot(offsetY: 20)
+
+        _ = sut.beginDragging(snapshot: snapshot)
+        sut.prepareDragEnd(
+            releaseVelocityY: 1_600,
+            targetOffsetY: 140,
+            currentOffsetY: 20
+        )
+        _ = sut.beginDragging(snapshot: snapshot)
+        let input = sut.endDragging(snapshot: snapshot)
+
+        XCTAssertEqual(
+            input,
+            .dragEnded(SessionWebRootDragEndContext(snapshot: snapshot, velocityY: 0))
+        )
+    }
+
+    func test_scrollInputAfterEndDragging_returnsExternalScroll_forProgrammaticFollowUp() {
+        let sut = SessionWebRootScrollAdapter()
+        let currentSnapshot = snapshot(offsetY: 20)
+        let followUpSnapshot = snapshot(offsetY: 44)
+
+        _ = sut.beginDragging(snapshot: currentSnapshot)
+        _ = sut.endDragging(snapshot: currentSnapshot)
+        let input = sut.scrollInput(snapshot: followUpSnapshot)
+
+        XCTAssertEqual(input, .externalScroll(followUpSnapshot))
+    }
+
+    private func snapshot(offsetY: CGFloat) -> SessionWebRootScrollSnapshot {
+        SessionWebRootScrollSnapshot(
+            offsetY: offsetY,
+            contentHeight: 1_200,
+            viewportHeight: 800,
+            adjustedContentInsetTop: 0,
+            adjustedContentInsetBottom: 0
+        )
+    }
+}


### PR DESCRIPTION
  ## 무엇을 바꿨나요?

  본 PR은 Clipy-72 2번째 PR로, WebView의 `scrollViewDidScroll` 콜백을 chrome 상태 전환에 바로 쓰지 않고 
  Session 화면이 이해할 수 있는 root scroll 입력으로 바꿉니다.

  ```mermaid
  ---
  title: Session chrome stacked PR 흐름
  ---
  graph LR
    PR1[PR1 화면/객체 파일 구조 정리] --> PR2[PR2 Web root scroll 입력 분리]
    PR2 --> PR3[PR3 Session chrome reducer 추가]
    PR3 --> PR4[PR4 ViewModel binding 연결]
  ```
  ```mermaid
  ---
  title: WebView scroll callback 변환 흐름
  ---
  graph LR
    UIKit[UIKit scroll callback] --> Adapter[Root scroll adapter]
    Adapter --> Policy[Root scroll policy]
    Policy --> Event[Session이 이해할 수 있는 root scroll event]
  ```

  ## 왜 바꿨나요?

  닫았던 이전 PR에서는 WebView scroll callback을 기준으로 chrome 전환을 해석하려고 했습니다.
  그런데 실제 WebView scroll은 callback 하나하나를 그대로 상태 전이에 연결하는 경우 해석해야 할 엣지케이스가 많아집니다.

  웹뷰를 아주 느리게 드래그하면 작은 offset 변화가 여러 번 나뉘어 들어오고, 빠르게 flick하면 drag가 끝난 뒤 deceleration callback이 계속 들어옵니다. 화면 끝에서는 rubber-band 움직임도 섞입니다.
  이 값들을 바로 chrome 상태 전환에 쓰면 “사용자가 chrome을 바꾸려는 의도”와 “WebView가 스크롤하면서 만든 노이즈”가 섞이게 됩니다.

  그래서 이 PR에서는 WebView를 상태 전환의 주체로 두지 않고, scroll callback을 Session feature가 이해할 수 있는 root scroll 입력으로 바꿔서 넘기게 했습니다. 해당 root scroll 입력이 실제 chrome 상태를 바꿀지는 다음 PR의 reducer에서 판단합니다.

  ## 변경 범위
  - WebView root scroll 입력 모델을 추가했습니다.
  - scroll callback을 root scroll event 후보로 바꾸는 adapter와 policy를 분리했습니다.
  - SessionWebView가 scroll lifecycle을 직접 해석하지 않고 adapter로 넘기게 했습니다.
  - 느린 드래그, 빠른 flick, 바운드 밖 움직임을 테스트로 고정했습니다.

  ## 제외한 범위
  - 이 PR에서는 chrome 상태를 실제로 바꾸지 않습니다.
  - TopBar toggle, BottomSheet 상태, Web root scroll 입력의 우선순위 판단은 다음 PR에서 다룹
    니다.
  - 외부 웹사이트의 custom scroll container 대응은 포함하지 않았습니다. (ex. 올리브영)

  ## 확인한 내용
  실제로 확인한 항목만 체크했습니다.
  - [x] 전체 stack 기준 CLIPY_IOS_VALIDATION_PROFILE=module
    CLIPY_IOS_VALIDATION_SCHEMES=FeatureSession CLIPY_IOS_VALIDATION_MODE=test ./scripts/
    validate_ios_profile.sh 통과
  - [x] 생성된 .xcodeproj, .xcworkspace, Derived/ 미포함 확인
  - [x] PR2 범위 git diff --check 통과

  ## 테스트와 문서

  SessionWebRootScrollPolicyTests와 SessionWebViewRootScrollAdapterTests를 추가했습니다.
  테스트는 WebView scroll callback을 그대로 chrome 전환으로 보지 않고, root scroll 입력으로 인정할 수 있는 경우만 남기는 규칙을 설명합니다.

  ## 리뷰어가 특히 봐야 할 부분

  - SessionWebView가 chrome 상태를 직접 바꾸지 않고 root scroll 입력만 만들어내는지 봐주세요.
  - 느린 드래그와 빠른 flick가 같은 callback 해석에 억지로 묶이지 않는지 봐주세요.
  - 바운드 밖 rubber-band 움직임이 chrome 전환 의도로 섞이지 않는지 봐주세요.

  ## 관련 이슈

  Related: #25
  Related: CLIPY-72
