### PR TITLE
[CLIPY-72] Session chrome reducer 추가

### DIFF
--- a/Modules/FeatureSession/Sources/SessionChrome/SessionChromeAction.swift
+++ b/Modules/FeatureSession/Sources/SessionChrome/SessionChromeAction.swift
@@ -1,0 +1,14 @@
+//
+//  SessionChromeAction.swift
+//  Clipy
+//
+//  Created by 박민서 on 7/5/26.
+//
+
+/// `SessionViewModel`이 chrome reducer에 넣는 action입니다.
+enum SessionChromeAction: Equatable {
+    case topBarToggle
+    case webRootScroll(SessionWebRootScrollInput)
+    case bottomSheetDragEnded(SessionBottomSheetAction)
+    case navigationFinishedAfterInitialLoad
+}

--- a/Modules/FeatureSession/Sources/SessionChrome/SessionChromeInteraction.swift
+++ b/Modules/FeatureSession/Sources/SessionChrome/SessionChromeInteraction.swift
@@ -1,0 +1,21 @@
+//
+//  SessionChromeInteraction.swift
+//  Clipy
+//
+//  Created by 박민서 on 7/5/26.
+//
+
+/// Web root drag 중 다른 chrome 입력을 막기 위해 현재 조작 주체를 기록합니다.
+enum SessionChromeInteraction: Equatable {
+    case idle
+    case webRootDragging(WebRootDragSession)
+
+    var isWebRootDragging: Bool {
+        switch self {
+        case .idle:
+            return false
+        case .webRootDragging:
+            return true
+        }
+    }
+}

--- a/Modules/FeatureSession/Sources/SessionChrome/SessionChromeReducer.swift
+++ b/Modules/FeatureSession/Sources/SessionChrome/SessionChromeReducer.swift
@@ -1,0 +1,166 @@
+//
+//  SessionChromeReducer.swift
+//  Clipy
+//
+//  Created by 박민서 on 7/5/26.
+//
+
+/// Top Bar, WebView root scroll, Bottom Sheet drag를 하나의 chrome 상태 전이로 모읍니다.
+struct SessionChromeReducer: Equatable {
+    let bottomSheetPolicy: SessionBottomSheetPolicy
+    let rootScrollPolicy: SessionWebRootScrollPolicy
+
+    init(
+        bottomSheetPolicy: SessionBottomSheetPolicy = .standard,
+        rootScrollPolicy: SessionWebRootScrollPolicy = SessionWebRootScrollPolicy()
+    ) {
+        self.bottomSheetPolicy = bottomSheetPolicy
+        self.rootScrollPolicy = rootScrollPolicy
+    }
+
+    func reduce(
+        _ state: SessionChromeReducerState,
+        action: SessionChromeAction
+    ) -> SessionChromeReducerState {
+        switch action {
+        case .topBarToggle:
+            return reduceTopBarToggle(state)
+        case .webRootScroll(let input):
+            return reduceWebRootScroll(state, input: input)
+        case .bottomSheetDragEnded(let action):
+            return reduceBottomSheetDragEnded(state, action: action)
+        case .navigationFinishedAfterInitialLoad:
+            return state.updatingPresentation(.browsingMinimized)
+        }
+    }
+
+    private func reduceTopBarToggle(
+        _ state: SessionChromeReducerState
+    ) -> SessionChromeReducerState {
+        guard !state.interaction.isWebRootDragging else {
+            return state
+        }
+
+        switch state.presentation {
+        case .browsingHidden:
+            return state.updatingPresentation(.browsingMinimized)
+        case .browsingMinimized:
+            return state.updatingPresentation(.browsingHidden)
+        case .comparingPeek(let topBarState):
+            return state.updatingPresentation(.comparingPeek(topBarState: topBarState.toggled))
+        case .comparingExpanded(let topBarState):
+            return state.updatingPresentation(.comparingExpanded(topBarState: topBarState.toggled))
+        }
+    }
+
+    private func reduceWebRootScroll(
+        _ state: SessionChromeReducerState,
+        input: SessionWebRootScrollInput
+    ) -> SessionChromeReducerState {
+        switch input {
+        case .dragBegan(let snapshot):
+            let anchorOffsetY = rootScrollPolicy.isInsideScrollableBounds(snapshot) ? snapshot.offsetY : nil
+            return state.updatingInteraction(.webRootDragging(WebRootDragSession(anchorOffsetY: anchorOffsetY)))
+        case .dragged(let snapshot):
+            return reduceWebRootDragged(state, snapshot: snapshot)
+        case .dragEnded(let context):
+            return reduceWebRootDragEnded(state, context: context)
+        case .decelerated:
+            return state.updatingInteraction(.idle)
+        case .externalScroll:
+            return state
+        }
+    }
+
+    private func reduceWebRootDragged(
+        _ state: SessionChromeReducerState,
+        snapshot: SessionWebRootScrollSnapshot
+    ) -> SessionChromeReducerState {
+        guard case .webRootDragging(var session) = state.interaction else {
+            return state
+        }
+
+        let movement = session.movement(for: snapshot, policy: rootScrollPolicy)
+        return state
+            .updatingInteraction(.webRootDragging(session))
+            .applyingRootScrollMovement(movement)
+    }
+
+    private func reduceWebRootDragEnded(
+        _ state: SessionChromeReducerState,
+        context: SessionWebRootDragEndContext
+    ) -> SessionChromeReducerState {
+        guard case .webRootDragging(var session) = state.interaction else {
+            return state.updatingInteraction(.idle)
+        }
+
+        let dragMovement = session.movement(for: context.snapshot, policy: rootScrollPolicy)
+        let flickMovement = dragMovement == nil ? rootScrollPolicy.flickMovement(from: context) : nil
+
+        return state
+            .updatingInteraction(.idle)
+            .applyingRootScrollMovement(dragMovement ?? flickMovement)
+    }
+
+    private func reduceBottomSheetDragEnded(
+        _ state: SessionChromeReducerState,
+        action: SessionBottomSheetAction
+    ) -> SessionChromeReducerState {
+        let nextBottomSheetState = bottomSheetPolicy.nextState(
+            from: state.presentation.bottomSheetState,
+            action: action
+        )
+
+        return state
+            .updatingInteraction(.idle)
+            .updatingPresentation(presentation(for: nextBottomSheetState, topBarState: state.presentation.topBarState))
+    }
+
+    private func presentation(
+        for bottomSheetState: SessionBottomSheetState,
+        topBarState: SessionTopBarState
+    ) -> SessionChromeState {
+        switch bottomSheetState {
+        case .hidden:
+            return .browsingHidden
+        case .minimized:
+            return .browsingMinimized
+        case .peek:
+            return .comparingPeek(topBarState: topBarState)
+        case .expanded:
+            return .comparingExpanded(topBarState: topBarState)
+        }
+    }
+}
+
+private extension SessionChromeReducerState {
+    func updatingPresentation(_ presentation: SessionChromeState) -> SessionChromeReducerState {
+        var state = self
+        state.presentation = presentation
+        return state
+    }
+
+    func updatingInteraction(_ interaction: SessionChromeInteraction) -> SessionChromeReducerState {
+        var state = self
+        state.interaction = interaction
+        return state
+    }
+
+    func applyingRootScrollMovement(
+        _ movement: SessionWebRootScrollMovement?
+    ) -> SessionChromeReducerState {
+        guard let movement,
+              movement.isEligibleForChromeTransition else {
+            return self
+        }
+
+        switch (presentation, movement.direction) {
+        case (.browsingMinimized, .down):
+            return updatingPresentation(.browsingHidden)
+        case (.browsingHidden, .up):
+            return updatingPresentation(.browsingMinimized)
+        default:
+            return self
+        }
+    }
+}

--- a/Modules/FeatureSession/Sources/SessionChrome/SessionChromeReducer.swift
+++ b/Modules/FeatureSession/Sources/SessionChrome/SessionChromeReducer.swift
@@ -30,7 +30,7 @@ struct SessionChromeReducer: Equatable {
         case .bottomSheetDragEnded(let action):
             return reduceBottomSheetDragEnded(state, action: action)
         case .navigationFinishedAfterInitialLoad:
-            return state.updatingPresentation(.browsingMinimized)
+            return reduceNavigationFinishedAfterInitialLoad(state)
         }
     }
 
@@ -114,6 +114,17 @@ struct SessionChromeReducer: Equatable {
         return state
             .updatingInteraction(.idle)
             .updatingPresentation(presentation(for: nextBottomSheetState, topBarState: state.presentation.topBarState))
+    }
+
+    private func reduceNavigationFinishedAfterInitialLoad(
+        _ state: SessionChromeReducerState
+    ) -> SessionChromeReducerState {
+        guard state.presentation == .newSession,
+              state.interaction == .idle else {
+            return state
+        }
+
+        return state.updatingPresentation(.browsingMinimized)
     }
 
     private func presentation(

--- a/Modules/FeatureSession/Sources/SessionChrome/SessionChromeReducer.swift
+++ b/Modules/FeatureSession/Sources/SessionChrome/SessionChromeReducer.swift
@@ -30,7 +30,7 @@ struct SessionChromeReducer: Equatable {
         case .bottomSheetDragEnded(let action):
             return reduceBottomSheetDragEnded(state, action: action)
         case .navigationFinishedAfterInitialLoad:
-            return reduceNavigationFinishedAfterInitialLoad(state)
+            return state.updatingPresentation(.browsingMinimized)
         }
     }
 
@@ -114,17 +114,6 @@ struct SessionChromeReducer: Equatable {
         return state
             .updatingInteraction(.idle)
             .updatingPresentation(presentation(for: nextBottomSheetState, topBarState: state.presentation.topBarState))
-    }
-
-    private func reduceNavigationFinishedAfterInitialLoad(
-        _ state: SessionChromeReducerState
-    ) -> SessionChromeReducerState {
-        guard state.presentation == .newSession,
-              state.interaction == .idle else {
-            return state
-        }
-
-        return state.updatingPresentation(.browsingMinimized)
     }
 
     private func presentation(

--- a/Modules/FeatureSession/Sources/SessionChrome/SessionChromeReducerState.swift
+++ b/Modules/FeatureSession/Sources/SessionChrome/SessionChromeReducerState.swift
@@ -1,0 +1,17 @@
+//
+//  SessionChromeReducerState.swift
+//  Clipy
+//
+//  Created by 박민서 on 7/5/26.
+//
+
+/// chrome presentation과 현재 interaction 소유권을 같이 넘겨 입력 충돌을 줄입니다.
+struct SessionChromeReducerState: Equatable {
+    var presentation: SessionChromeState
+    var interaction: SessionChromeInteraction
+
+    static let newSession = SessionChromeReducerState(
+        presentation: .newSession,
+        interaction: .idle
+    )
+}

--- a/Modules/FeatureSession/Sources/SessionChrome/SessionChromeState.swift
+++ b/Modules/FeatureSession/Sources/SessionChrome/SessionChromeState.swift
@@ -1,0 +1,40 @@
+//
+//  SessionChromeState.swift
+//  Clipy
+//
+//  Created by 박민서 on 7/5/26.
+//
+
+/// Session 화면의 Top Bar와 Bottom Sheet를 한 chrome 상태로 묶습니다.
+enum SessionChromeState: Equatable {
+    case browsingHidden
+    case browsingMinimized
+    case comparingPeek(topBarState: SessionTopBarState)
+    case comparingExpanded(topBarState: SessionTopBarState)
+
+    static let newSession = SessionChromeState.comparingPeek(topBarState: .unfolded)
+
+    var topBarState: SessionTopBarState {
+        switch self {
+        case .browsingHidden:
+            return .folded
+        case .browsingMinimized:
+            return .unfolded
+        case .comparingPeek(let topBarState), .comparingExpanded(let topBarState):
+            return topBarState
+        }
+    }
+
+    var bottomSheetState: SessionBottomSheetState {
+        switch self {
+        case .browsingHidden:
+            return .hidden
+        case .browsingMinimized:
+            return .minimized
+        case .comparingPeek:
+            return .peek
+        case .comparingExpanded:
+            return .expanded
+        }
+    }
+}

--- a/Modules/FeatureSession/Sources/SessionChrome/WebRootDragSession.swift
+++ b/Modules/FeatureSession/Sources/SessionChrome/WebRootDragSession.swift
@@ -1,0 +1,42 @@
+//
+//  WebRootDragSession.swift
+//  Clipy
+//
+//  Created by 박민서 on 7/5/26.
+//
+
+import CoreGraphics
+
+/// WebView drag 한 번 동안 마지막 유효 offset을 잡아 threshold를 누적 판단합니다.
+struct WebRootDragSession: Equatable {
+    private var anchorOffsetY: CGFloat?
+
+    init(anchorOffsetY: CGFloat?) {
+        self.anchorOffsetY = anchorOffsetY
+    }
+
+    mutating func movement(
+        for snapshot: SessionWebRootScrollSnapshot,
+        policy: SessionWebRootScrollPolicy
+    ) -> SessionWebRootScrollMovement? {
+        guard policy.isInsideScrollableBounds(snapshot) else {
+            anchorOffsetY = nil
+            return nil
+        }
+
+        guard let anchorOffsetY else {
+            self.anchorOffsetY = snapshot.offsetY
+            return nil
+        }
+
+        guard let movement = policy.movement(
+            fromAnchorOffsetY: anchorOffsetY,
+            to: snapshot
+        ) else {
+            return nil
+        }
+
+        self.anchorOffsetY = snapshot.offsetY
+        return movement
+    }
+}

--- a/Modules/FeatureSession/Sources/SessionWeb/RootScroll/SessionWebRootScrollAdapter.swift
+++ b/Modules/FeatureSession/Sources/SessionWeb/RootScroll/SessionWebRootScrollAdapter.swift
@@ -1,0 +1,71 @@
+//
+//  SessionWebRootScrollAdapter.swift
+//  Clipy
+//
+//  Created by 박민서 on 7/5/26.
+//
+
+import CoreGraphics
+
+/// UIScrollViewDelegate callback 순서를 chrome reducer가 읽을 수 있는 root scroll input으로 바꿉니다.
+final class SessionWebRootScrollAdapter {
+    private var isDragging = false
+    private var pendingDragEndContentVelocityY: CGFloat?
+
+    func beginDragging(snapshot: SessionWebRootScrollSnapshot) -> SessionWebRootScrollInput {
+        isDragging = true
+        pendingDragEndContentVelocityY = nil
+        return .dragBegan(snapshot)
+    }
+
+    func scrollInput(snapshot: SessionWebRootScrollSnapshot) -> SessionWebRootScrollInput {
+        guard isDragging else {
+            return .externalScroll(snapshot)
+        }
+
+        return .dragged(snapshot)
+    }
+
+    func prepareDragEnd(
+        releaseVelocityY: CGFloat,
+        targetOffsetY: CGFloat,
+        currentOffsetY: CGFloat
+    ) {
+        pendingDragEndContentVelocityY = Self.contentVelocityY(
+            releaseVelocityY: releaseVelocityY,
+            targetOffsetY: targetOffsetY,
+            currentOffsetY: currentOffsetY
+        )
+    }
+
+    func endDragging(
+        snapshot: SessionWebRootScrollSnapshot
+    ) -> SessionWebRootScrollInput {
+        defer {
+            isDragging = false
+            pendingDragEndContentVelocityY = nil
+        }
+
+        return .dragEnded(
+            SessionWebRootDragEndContext(
+                snapshot: snapshot,
+                velocityY: pendingDragEndContentVelocityY ?? 0
+            )
+        )
+    }
+
+    /// 손을 뗀 순간에는 UIKit velocity 부호보다 예상 target offset 차이가 page 방향을 더 직접적으로 보여줍니다.
+    static func contentVelocityY(
+        releaseVelocityY: CGFloat,
+        targetOffsetY: CGFloat,
+        currentOffsetY: CGFloat
+    ) -> CGFloat {
+        let projectedDeltaY = targetOffsetY - currentOffsetY
+        guard projectedDeltaY != 0 else {
+            return 0
+        }
+
+        let speed = abs(releaseVelocityY)
+        return projectedDeltaY > 0 ? speed : -speed
+    }
+}

--- a/Modules/FeatureSession/Sources/SessionWeb/RootScroll/SessionWebRootScrollInput.swift
+++ b/Modules/FeatureSession/Sources/SessionWeb/RootScroll/SessionWebRootScrollInput.swift
@@ -1,0 +1,33 @@
+//
+//  SessionWebRootScrollInput.swift
+//  Clipy
+//
+//  Created by 박민서 on 7/5/26.
+//
+
+import CoreGraphics
+
+/// UIScrollView 전체를 넘기지 않고 chrome 전이에 필요한 위치와 page 크기만 남긴 값입니다.
+struct SessionWebRootScrollSnapshot: Equatable {
+    let offsetY: CGFloat
+    let contentHeight: CGFloat
+    let viewportHeight: CGFloat
+    let adjustedContentInsetTop: CGFloat
+    let adjustedContentInsetBottom: CGFloat
+}
+
+/// 사용자가 WebView drag를 끝낸 순간 reducer가 한 번만 flick를 판단할 때 쓰는 입력입니다.
+struct SessionWebRootDragEndContext: Equatable {
+    let snapshot: SessionWebRootScrollSnapshot
+    /// content offset 기준 속도입니다. 양수면 page down, 음수면 page up 방향입니다.
+    let velocityY: CGFloat
+}
+
+/// WebKit/UIScrollView callback을 FeatureSession 안에서 다루기 좋게 바꾼 lifecycle input입니다.
+enum SessionWebRootScrollInput: Equatable {
+    case dragBegan(SessionWebRootScrollSnapshot)
+    case dragged(SessionWebRootScrollSnapshot)
+    case dragEnded(SessionWebRootDragEndContext)
+    case decelerated(SessionWebRootScrollSnapshot)
+    case externalScroll(SessionWebRootScrollSnapshot)
+}

--- a/Modules/FeatureSession/Sources/SessionWeb/RootScroll/SessionWebRootScrollPolicy.swift
+++ b/Modules/FeatureSession/Sources/SessionWeb/RootScroll/SessionWebRootScrollPolicy.swift
@@ -1,0 +1,89 @@
+//
+//  SessionWebRootScrollPolicy.swift
+//  Clipy
+//
+//  Created by 박민서 on 7/5/26.
+//
+
+import CoreGraphics
+
+/// Root scroll이 chrome 전환에 쓸 수 있는 방향과 page 조건을 계산합니다.
+struct SessionWebRootScrollPolicy: Equatable {
+    private let dragThreshold: CGFloat
+    private let flickVelocityThreshold: CGFloat
+    private let minimumScrollableViewportRatio: CGFloat
+
+    init(
+        dragThreshold: CGFloat = 12,
+        flickVelocityThreshold: CGFloat = 1_200,
+        minimumScrollableViewportRatio: CGFloat = 0.20
+    ) {
+        self.dragThreshold = dragThreshold
+        self.flickVelocityThreshold = flickVelocityThreshold
+        self.minimumScrollableViewportRatio = minimumScrollableViewportRatio
+    }
+
+    func movement(
+        fromAnchorOffsetY anchorOffsetY: CGFloat,
+        to snapshot: SessionWebRootScrollSnapshot
+    ) -> SessionWebRootScrollMovement? {
+        guard isInsideScrollableBounds(snapshot) else {
+            return nil
+        }
+
+        let deltaY = snapshot.offsetY - anchorOffsetY
+        guard abs(deltaY) >= dragThreshold else {
+            return nil
+        }
+
+        return SessionWebRootScrollMovement(
+            direction: deltaY > 0 ? .down : .up,
+            isEligibleForChromeTransition: isEligibleForChromeTransition(snapshot)
+        )
+    }
+
+    func flickMovement(
+        from context: SessionWebRootDragEndContext
+    ) -> SessionWebRootScrollMovement? {
+        guard isInsideScrollableBounds(context.snapshot),
+              abs(context.velocityY) >= flickVelocityThreshold else {
+            return nil
+        }
+
+        return SessionWebRootScrollMovement(
+            direction: context.velocityY > 0 ? .down : .up,
+            isEligibleForChromeTransition: isEligibleForChromeTransition(context.snapshot)
+        )
+    }
+
+    func isInsideScrollableBounds(_ snapshot: SessionWebRootScrollSnapshot) -> Bool {
+        // rubber-band offset은 실제 page 이동이 아니어서 chrome 전이 신호에서 빼둡니다.
+        let minimumOffsetY = -max(snapshot.adjustedContentInsetTop, 0)
+        let maximumOffsetY = max(
+            minimumOffsetY,
+            max(snapshot.contentHeight, 0) - max(snapshot.viewportHeight, 0) + max(snapshot.adjustedContentInsetBottom, 0)
+        )
+
+        return snapshot.offsetY >= minimumOffsetY && snapshot.offsetY <= maximumOffsetY
+    }
+
+    private func isEligibleForChromeTransition(_ snapshot: SessionWebRootScrollSnapshot) -> Bool {
+        let viewportHeight = max(snapshot.viewportHeight, 0)
+        let scrollableHeight = max(
+            snapshot.contentHeight + snapshot.adjustedContentInsetTop + snapshot.adjustedContentInsetBottom - viewportHeight,
+            0
+        )
+        return scrollableHeight >= viewportHeight * minimumScrollableViewportRatio
+    }
+}
+
+/// Chrome reducer가 presentation 전이를 판단할 때 쓰는 root scroll movement입니다.
+struct SessionWebRootScrollMovement: Equatable {
+    let direction: SessionWebRootScrollDirection
+    let isEligibleForChromeTransition: Bool
+}
+
+enum SessionWebRootScrollDirection: Equatable {
+    case up
+    case down
+}

--- a/Modules/FeatureSession/Sources/SessionWeb/RootScroll/SessionWebView+Scroll.swift
+++ b/Modules/FeatureSession/Sources/SessionWeb/RootScroll/SessionWebView+Scroll.swift
@@ -1,0 +1,49 @@
+//
+//  SessionWebView+Scroll.swift
+//  Clipy
+//
+//  Created by 박민서 on 7/5/26.
+//
+
+import UIKit
+
+extension SessionWebView: UIScrollViewDelegate {
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        beginRootDragging(snapshot: scrollSnapshot(from: scrollView))
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard !scrollView.isDecelerating else {
+            return
+        }
+
+        emitRootDraggingIfNeeded(snapshot: scrollSnapshot(from: scrollView))
+    }
+
+    func scrollViewWillEndDragging(
+        _ scrollView: UIScrollView,
+        withVelocity velocity: CGPoint,
+        targetContentOffset: UnsafeMutablePointer<CGPoint>
+    ) {
+        prepareRootDragEnd(
+            releaseVelocityY: velocity.y,
+            targetOffsetY: targetContentOffset.pointee.y,
+            currentOffsetY: scrollView.contentOffset.y
+        )
+    }
+
+    func scrollViewDidEndDragging(
+        _ scrollView: UIScrollView,
+        willDecelerate _: Bool
+    ) {
+        endRootDragging(snapshot: scrollSnapshot(from: scrollView))
+    }
+
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        emitRootScroll(.decelerated(scrollSnapshot(from: scrollView)))
+    }
+
+    func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+        emitRootScroll(.externalScroll(scrollSnapshot(from: scrollView)))
+    }
+}

--- a/Modules/FeatureSession/Sources/SessionWeb/SessionWebView.swift
+++ b/Modules/FeatureSession/Sources/SessionWeb/SessionWebView.swift
@@ -20,8 +20,10 @@ final class SessionWebView: UIView {
     fileprivate let stateRelay = BehaviorRelay(value: SessionBrowserState.empty)
     /// WebKit navigation 실패를 feature-owned event로 내보내는 relay입니다.
     fileprivate let navigationFailureRelay = PublishRelay<SessionWebNavigationFailure>()
+    fileprivate let rootScrollRelay = PublishRelay<SessionWebRootScrollInput>()
     /// WebKit KVO lifecycle을 SessionWebView 생명주기에 묶어두는 token 목록입니다.
     private var observations: [NSKeyValueObservation] = []
+    private let rootScrollAdapter = SessionWebRootScrollAdapter()
 
     override init(frame: CGRect) {
         webView = WKWebView(frame: .zero)
@@ -40,6 +42,7 @@ final class SessionWebView: UIView {
         backgroundColor = .systemBackground
 
         webView.navigationDelegate = self
+        webView.scrollView.delegate = self
         webView.allowsBackForwardNavigationGestures = true
         webView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -82,6 +85,44 @@ final class SessionWebView: UIView {
     func emitNavigationFailure(_ failure: SessionWebNavigationFailure) {
         navigationFailureRelay.accept(failure)
     }
+
+    func beginRootDragging(snapshot: SessionWebRootScrollSnapshot) {
+        emitRootScroll(rootScrollAdapter.beginDragging(snapshot: snapshot))
+    }
+
+    func emitRootDraggingIfNeeded(snapshot: SessionWebRootScrollSnapshot) {
+        emitRootScroll(rootScrollAdapter.scrollInput(snapshot: snapshot))
+    }
+
+    func prepareRootDragEnd(
+        releaseVelocityY: CGFloat,
+        targetOffsetY: CGFloat,
+        currentOffsetY: CGFloat
+    ) {
+        rootScrollAdapter.prepareDragEnd(
+            releaseVelocityY: releaseVelocityY,
+            targetOffsetY: targetOffsetY,
+            currentOffsetY: currentOffsetY
+        )
+    }
+
+    func endRootDragging(snapshot: SessionWebRootScrollSnapshot) {
+        emitRootScroll(rootScrollAdapter.endDragging(snapshot: snapshot))
+    }
+
+    func emitRootScroll(_ input: SessionWebRootScrollInput) {
+        rootScrollRelay.accept(input)
+    }
+
+    func scrollSnapshot(from scrollView: UIScrollView) -> SessionWebRootScrollSnapshot {
+        SessionWebRootScrollSnapshot(
+            offsetY: scrollView.contentOffset.y,
+            contentHeight: scrollView.contentSize.height,
+            viewportHeight: scrollView.bounds.height,
+            adjustedContentInsetTop: scrollView.adjustedContentInset.top,
+            adjustedContentInsetBottom: scrollView.adjustedContentInset.bottom
+        )
+    }
 }
 
 // MARK: - Interface
@@ -123,5 +164,10 @@ extension Reactive where Base: SessionWebView {
     /// WebKit navigation 실패를 ViewModel이나 ViewController가 처리할 수 있는 event로 제공합니다.
     var navigationFailure: Signal<SessionWebNavigationFailure> {
         base.navigationFailureRelay.asSignal()
+    }
+
+    /// WebView root scroll lifecycle을 chrome reducer input으로 제공합니다.
+    var rootScroll: Signal<SessionWebRootScrollInput> {
+        base.rootScrollRelay.asSignal()
     }
 }

--- a/Modules/FeatureSession/Tests/SessionChrome/SessionChromeReducerTestFixture.swift
+++ b/Modules/FeatureSession/Tests/SessionChrome/SessionChromeReducerTestFixture.swift
@@ -1,0 +1,68 @@
+//
+//  SessionChromeReducerTestFixture.swift
+//  Clipy
+//
+//  Created by 박민서 on 7/5/26.
+//
+
+import CoreGraphics
+
+@testable import FeatureSession
+
+enum SessionChromeReducerTestFixture {
+    static func state(showing presentation: SessionChromeState) -> SessionChromeReducerState {
+        SessionChromeReducerState(
+            presentation: presentation,
+            interaction: .idle
+        )
+    }
+
+    static func draggingState(showing presentation: SessionChromeState) -> SessionChromeReducerState {
+        SessionChromeReducerState(
+            presentation: presentation,
+            interaction: .webRootDragging(WebRootDragSession(anchorOffsetY: 0))
+        )
+    }
+
+    static func snapshot(
+        offsetY: CGFloat,
+        contentHeight: CGFloat = 1_200,
+        viewportHeight: CGFloat = 800,
+        adjustedContentInsetTop: CGFloat = 0,
+        adjustedContentInsetBottom: CGFloat = 0
+    ) -> SessionWebRootScrollSnapshot {
+        SessionWebRootScrollSnapshot(
+            offsetY: offsetY,
+            contentHeight: contentHeight,
+            viewportHeight: viewportHeight,
+            adjustedContentInsetTop: adjustedContentInsetTop,
+            adjustedContentInsetBottom: adjustedContentInsetBottom
+        )
+    }
+
+    static func dragEnd(
+        offsetY: CGFloat,
+        velocityY: CGFloat
+    ) -> SessionWebRootDragEndContext {
+        SessionWebRootDragEndContext(
+            snapshot: snapshot(offsetY: offsetY),
+            velocityY: velocityY
+        )
+    }
+
+    static func bottomSheetDragEnded(
+        endVisibleHeight: CGFloat,
+        translationY: CGFloat,
+        velocityY: CGFloat = 0,
+        availableHeight: CGFloat = 760
+    ) -> SessionBottomSheetAction {
+        .dragEnded(
+            SessionBottomSheetDragEndContext(
+                translationY: translationY,
+                velocityY: velocityY,
+                endOffset: availableHeight - endVisibleHeight,
+                availableHeight: availableHeight
+            )
+        )
+    }
+}

--- a/Modules/FeatureSession/Tests/SessionChrome/SessionChromeReducerTests.swift
+++ b/Modules/FeatureSession/Tests/SessionChrome/SessionChromeReducerTests.swift
@@ -103,4 +103,35 @@ final class SessionChromeReducerTests: XCTestCase {
 
         XCTAssertEqual(state.presentation, .browsingMinimized)
     }
+
+    func test_navigationAfterInitialLoad_keepsNewSessionChrome_duringActiveWebRootDrag() {
+        let sut = SessionChromeReducer()
+        let dragging = Fixture.draggingState(showing: .newSession)
+
+        let state = sut.reduce(
+            dragging,
+            action: .navigationFinishedAfterInitialLoad
+        )
+
+        XCTAssertEqual(state, dragging)
+    }
+
+    func test_navigationAfterInitialLoad_keepsChangedChrome_forUserInteractionDuringLoading() {
+        let sut = SessionChromeReducer()
+        let changedStates: [SessionChromeState] = [
+            .browsingHidden,
+            .browsingMinimized,
+            .comparingPeek(topBarState: .folded),
+            .comparingExpanded(topBarState: .unfolded)
+        ]
+
+        changedStates.forEach { presentation in
+            let state = sut.reduce(
+                Fixture.state(showing: presentation),
+                action: .navigationFinishedAfterInitialLoad
+            )
+
+            XCTAssertEqual(state.presentation, presentation)
+        }
+    }
 }

--- a/Modules/FeatureSession/Tests/SessionChrome/SessionChromeReducerTests.swift
+++ b/Modules/FeatureSession/Tests/SessionChrome/SessionChromeReducerTests.swift
@@ -104,23 +104,10 @@ final class SessionChromeReducerTests: XCTestCase {
         XCTAssertEqual(state.presentation, .browsingMinimized)
     }
 
-    func test_navigationAfterInitialLoad_keepsNewSessionChrome_duringActiveWebRootDrag() {
-        let sut = SessionChromeReducer()
-        let dragging = Fixture.draggingState(showing: .newSession)
-
-        let state = sut.reduce(
-            dragging,
-            action: .navigationFinishedAfterInitialLoad
-        )
-
-        XCTAssertEqual(state, dragging)
-    }
-
-    func test_navigationAfterInitialLoad_keepsChangedChrome_forUserInteractionDuringLoading() {
+    func test_navigationAfterInitialLoad_setsBrowsingMinimized_afterChromeInteractionDuringLoading() {
         let sut = SessionChromeReducer()
         let changedStates: [SessionChromeState] = [
             .browsingHidden,
-            .browsingMinimized,
             .comparingPeek(topBarState: .folded),
             .comparingExpanded(topBarState: .unfolded)
         ]
@@ -131,7 +118,20 @@ final class SessionChromeReducerTests: XCTestCase {
                 action: .navigationFinishedAfterInitialLoad
             )
 
-            XCTAssertEqual(state.presentation, presentation)
+            XCTAssertEqual(state.presentation, .browsingMinimized)
         }
+    }
+
+    func test_navigationAfterInitialLoad_keepsActiveInteraction_whileApplyingMinimizedBaseline() {
+        let sut = SessionChromeReducer()
+        let dragging = Fixture.draggingState(showing: .newSession)
+
+        let state = sut.reduce(
+            dragging,
+            action: .navigationFinishedAfterInitialLoad
+        )
+
+        XCTAssertEqual(state.presentation, .browsingMinimized)
+        XCTAssertEqual(state.interaction, dragging.interaction)
     }
 }

--- a/Modules/FeatureSession/Tests/SessionChrome/SessionChromeReducerTests.swift
+++ b/Modules/FeatureSession/Tests/SessionChrome/SessionChromeReducerTests.swift
@@ -1,0 +1,106 @@
+//
+//  SessionChromeReducerTests.swift
+//  Clipy
+//
+//  Created by 박민서 on 7/5/26.
+//
+
+import XCTest
+
+@testable import FeatureSession
+
+final class SessionChromeReducerTests: XCTestCase {
+    typealias Fixture = SessionChromeReducerTestFixture
+
+    func test_topBarToggleBetweenBrowsingStates_switchesHiddenAndMinimized_forFocusedBrowsing() {
+        let sut = SessionChromeReducer()
+
+        let hidden = sut.reduce(
+            Fixture.state(showing: .browsingMinimized),
+            action: .topBarToggle
+        )
+        let minimized = sut.reduce(
+            Fixture.state(showing: .browsingHidden),
+            action: .topBarToggle
+        )
+
+        XCTAssertEqual(hidden.presentation, .browsingHidden)
+        XCTAssertEqual(minimized.presentation, .browsingMinimized)
+    }
+
+    func test_topBarToggleInPeek_changesTopBarOnly_keepsBottomSheetPeek() {
+        let sut = SessionChromeReducer()
+
+        let folded = sut.reduce(
+            Fixture.state(showing: .comparingPeek(topBarState: .unfolded)),
+            action: .topBarToggle
+        )
+        let unfolded = sut.reduce(
+            Fixture.state(showing: .comparingPeek(topBarState: .folded)),
+            action: .topBarToggle
+        )
+
+        XCTAssertEqual(folded.presentation, .comparingPeek(topBarState: .folded))
+        XCTAssertEqual(unfolded.presentation, .comparingPeek(topBarState: .unfolded))
+    }
+
+    func test_topBarToggleInExpanded_changesTopBarOnly_keepsBottomSheetExpanded() {
+        let sut = SessionChromeReducer()
+
+        let folded = sut.reduce(
+            Fixture.state(showing: .comparingExpanded(topBarState: .unfolded)),
+            action: .topBarToggle
+        )
+        let unfolded = sut.reduce(
+            Fixture.state(showing: .comparingExpanded(topBarState: .folded)),
+            action: .topBarToggle
+        )
+
+        XCTAssertEqual(folded.presentation, .comparingExpanded(topBarState: .folded))
+        XCTAssertEqual(unfolded.presentation, .comparingExpanded(topBarState: .unfolded))
+    }
+
+    func test_topBarToggleDuringWebRootDragging_isIgnored_forInteractionOwnership() {
+        let sut = SessionChromeReducer()
+        let state = Fixture.draggingState(showing: .browsingMinimized)
+
+        let nextState = sut.reduce(state, action: .topBarToggle)
+
+        XCTAssertEqual(nextState, state)
+    }
+
+    func test_bottomSheetDrag_routesThroughChromeReducer_forSharedChromeState() {
+        let sut = SessionChromeReducer()
+        let state = sut.reduce(
+            Fixture.state(showing: .comparingPeek(topBarState: .unfolded)),
+            action: .bottomSheetDragEnded(
+                Fixture.bottomSheetDragEnded(endVisibleHeight: 240, translationY: 46)
+            )
+        )
+
+        XCTAssertEqual(state.presentation, .browsingMinimized)
+    }
+
+    func test_bottomSheetDragDuringWebRootDragging_appliesSheetResultAndClearsInteraction() {
+        let sut = SessionChromeReducer()
+        let state = sut.reduce(
+            Fixture.draggingState(showing: .browsingMinimized),
+            action: .bottomSheetDragEnded(
+                Fixture.bottomSheetDragEnded(endVisibleHeight: 170, translationY: -50)
+            )
+        )
+
+        XCTAssertEqual(state.presentation, .comparingPeek(topBarState: .unfolded))
+        XCTAssertEqual(state.interaction, .idle)
+    }
+
+    func test_navigationAfterInitialLoad_restoresBrowsingMinimized_forDefaultViewport() {
+        let sut = SessionChromeReducer()
+        let state = sut.reduce(
+            .newSession,
+            action: .navigationFinishedAfterInitialLoad
+        )
+
+        XCTAssertEqual(state.presentation, .browsingMinimized)
+    }
+}

--- a/Modules/FeatureSession/Tests/SessionChrome/SessionChromeReducerWebRootScrollTests.swift
+++ b/Modules/FeatureSession/Tests/SessionChrome/SessionChromeReducerWebRootScrollTests.swift
@@ -216,6 +216,36 @@ final class SessionChromeReducerWebRootScrollTests: XCTestCase {
         XCTAssertEqual(stillMinimized.presentation, .browsingMinimized)
     }
 
+    func test_dragEndOppositeVelocity_prefersDragDistance_forRootScrollIntent() {
+        let sut = SessionChromeReducer()
+        let dragging = sut.reduce(
+            Fixture.state(showing: .browsingMinimized),
+            action: .webRootScroll(.dragBegan(Fixture.snapshot(offsetY: 0)))
+        )
+        let hidden = sut.reduce(
+            dragging,
+            action: .webRootScroll(.dragEnded(Fixture.dragEnd(offsetY: 14, velocityY: -1_600)))
+        )
+
+        XCTAssertEqual(hidden.presentation, .browsingHidden)
+        XCTAssertEqual(hidden.interaction, .idle)
+    }
+
+    func test_dragEndOppositeVelocityFromHidden_prefersDragDistance_forRootScrollIntent() {
+        let sut = SessionChromeReducer()
+        let dragging = sut.reduce(
+            Fixture.state(showing: .browsingHidden),
+            action: .webRootScroll(.dragBegan(Fixture.snapshot(offsetY: 40)))
+        )
+        let minimized = sut.reduce(
+            dragging,
+            action: .webRootScroll(.dragEnded(Fixture.dragEnd(offsetY: 24, velocityY: 1_600)))
+        )
+
+        XCTAssertEqual(minimized.presentation, .browsingMinimized)
+        XCTAssertEqual(minimized.interaction, .idle)
+    }
+
     func test_dragEndOutOfBoundsWithHighVelocity_keepsChrome_andClearsInteraction() {
         let sut = SessionChromeReducer()
         let dragging = sut.reduce(

--- a/Modules/FeatureSession/Tests/SessionChrome/SessionChromeReducerWebRootScrollTests.swift
+++ b/Modules/FeatureSession/Tests/SessionChrome/SessionChromeReducerWebRootScrollTests.swift
@@ -1,0 +1,233 @@
+//
+//  SessionChromeReducerWebRootScrollTests.swift
+//  Clipy
+//
+//  Created by 박민서 on 7/5/26.
+//
+
+import XCTest
+
+@testable import FeatureSession
+
+final class SessionChromeReducerWebRootScrollTests: XCTestCase {
+    typealias Fixture = SessionChromeReducerTestFixture
+
+    func test_externalScroll_doesNotChangeChrome_withoutActiveDragSession() {
+        let sut = SessionChromeReducer()
+        let state = sut.reduce(
+            Fixture.state(showing: .browsingMinimized),
+            action: .webRootScroll(.externalScroll(Fixture.snapshot(offsetY: 40)))
+        )
+
+        XCTAssertEqual(state.presentation, .browsingMinimized)
+        XCTAssertEqual(state.interaction, .idle)
+    }
+
+    func test_draggedRootScroll_hidesChrome_onlyInsideActiveDragSession() {
+        let sut = SessionChromeReducer()
+        let dragging = sut.reduce(
+            Fixture.state(showing: .browsingMinimized),
+            action: .webRootScroll(.dragBegan(Fixture.snapshot(offsetY: 0)))
+        )
+        let hidden = sut.reduce(
+            dragging,
+            action: .webRootScroll(.dragged(Fixture.snapshot(offsetY: 14)))
+        )
+        let ignoredWithoutDrag = sut.reduce(
+            Fixture.state(showing: .browsingMinimized),
+            action: .webRootScroll(.dragged(Fixture.snapshot(offsetY: 14)))
+        )
+
+        XCTAssertEqual(hidden.presentation, .browsingHidden)
+        XCTAssertEqual(ignoredWithoutDrag.presentation, .browsingMinimized)
+    }
+
+    func test_draggedRootScrollUp_restoresMinimizedChrome_fromHiddenBrowsing() {
+        let sut = SessionChromeReducer()
+        let dragging = sut.reduce(
+            Fixture.state(showing: .browsingHidden),
+            action: .webRootScroll(.dragBegan(Fixture.snapshot(offsetY: 40)))
+        )
+        let minimized = sut.reduce(
+            dragging,
+            action: .webRootScroll(.dragged(Fixture.snapshot(offsetY: 24)))
+        )
+
+        XCTAssertEqual(minimized.presentation, .browsingMinimized)
+    }
+
+    func test_slowRootScroll_accumulatesMovementInsideActiveDragSession() {
+        let sut = SessionChromeReducer()
+        let dragging = sut.reduce(
+            Fixture.state(showing: .browsingMinimized),
+            action: .webRootScroll(.dragBegan(Fixture.snapshot(offsetY: 0)))
+        )
+        let belowThreshold = sut.reduce(
+            dragging,
+            action: .webRootScroll(.dragged(Fixture.snapshot(offsetY: 6)))
+        )
+        let hidden = sut.reduce(
+            belowThreshold,
+            action: .webRootScroll(.dragged(Fixture.snapshot(offsetY: 13)))
+        )
+
+        XCTAssertEqual(belowThreshold.presentation, .browsingMinimized)
+        XCTAssertEqual(hidden.presentation, .browsingHidden)
+    }
+
+    func test_shortRootPageMovement_keepsChrome_forIneligibleScrollSurface() {
+        let sut = SessionChromeReducer()
+        let dragging = sut.reduce(
+            Fixture.state(showing: .browsingMinimized),
+            action: .webRootScroll(.dragBegan(Fixture.snapshot(offsetY: 0, contentHeight: 900)))
+        )
+        let unchanged = sut.reduce(
+            dragging,
+            action: .webRootScroll(.dragged(Fixture.snapshot(offsetY: 30, contentHeight: 900)))
+        )
+
+        XCTAssertEqual(unchanged.presentation, .browsingMinimized)
+    }
+
+    func test_topRubberBandRebound_doesNotChangeChrome_forEdgeBounceNoise() {
+        let sut = SessionChromeReducer()
+        let dragging = sut.reduce(
+            Fixture.state(showing: .browsingHidden),
+            action: .webRootScroll(.dragBegan(Fixture.snapshot(offsetY: 4)))
+        )
+        let rubberBand = sut.reduce(
+            dragging,
+            action: .webRootScroll(.dragged(Fixture.snapshot(offsetY: -18)))
+        )
+        let rebound = sut.reduce(
+            rubberBand,
+            action: .webRootScroll(.dragged(Fixture.snapshot(offsetY: 0)))
+        )
+
+        XCTAssertEqual(rebound.presentation, .browsingHidden)
+    }
+
+    func test_bottomRubberBandRebound_doesNotChangeChrome_forEdgeBounceNoise() {
+        let sut = SessionChromeReducer()
+        let dragging = sut.reduce(
+            Fixture.state(showing: .browsingMinimized),
+            action: .webRootScroll(.dragBegan(Fixture.snapshot(offsetY: 380)))
+        )
+        let rubberBand = sut.reduce(
+            dragging,
+            action: .webRootScroll(.dragged(Fixture.snapshot(offsetY: 430)))
+        )
+        let rebound = sut.reduce(
+            rubberBand,
+            action: .webRootScroll(.dragged(Fixture.snapshot(offsetY: 400)))
+        )
+
+        XCTAssertEqual(rebound.presentation, .browsingMinimized)
+    }
+
+    func test_dragBeginningOutOfBounds_reanchorsAfterRebound_beforeChangingChrome() {
+        let sut = SessionChromeReducer()
+        let dragging = sut.reduce(
+            Fixture.state(showing: .browsingMinimized),
+            action: .webRootScroll(.dragBegan(Fixture.snapshot(offsetY: -20)))
+        )
+        let rebound = sut.reduce(
+            dragging,
+            action: .webRootScroll(.dragged(Fixture.snapshot(offsetY: 0)))
+        )
+        let hidden = sut.reduce(
+            rebound,
+            action: .webRootScroll(.dragged(Fixture.snapshot(offsetY: 14)))
+        )
+
+        XCTAssertEqual(rebound.presentation, .browsingMinimized)
+        XCTAssertEqual(hidden.presentation, .browsingHidden)
+    }
+
+    func test_decelerationAfterDragEnd_doesNotChangeChrome() {
+        let sut = SessionChromeReducer()
+        let dragging = sut.reduce(
+            Fixture.state(showing: .browsingMinimized),
+            action: .webRootScroll(.dragBegan(Fixture.snapshot(offsetY: 0)))
+        )
+        let ended = sut.reduce(
+            dragging,
+            action: .webRootScroll(.dragEnded(Fixture.dragEnd(offsetY: 4, velocityY: 0)))
+        )
+        let decelerated = sut.reduce(
+            ended,
+            action: .webRootScroll(.decelerated(Fixture.snapshot(offsetY: 40)))
+        )
+
+        XCTAssertEqual(decelerated.presentation, .browsingMinimized)
+        XCTAssertEqual(decelerated.interaction, .idle)
+    }
+
+    func test_topBarToggleAfterDragEnd_isAccepted_evenIfScrollViewIsDecelerating() {
+        let sut = SessionChromeReducer()
+        let dragging = sut.reduce(
+            Fixture.state(showing: .browsingMinimized),
+            action: .webRootScroll(.dragBegan(Fixture.snapshot(offsetY: 0)))
+        )
+        let ended = sut.reduce(
+            dragging,
+            action: .webRootScroll(.dragEnded(Fixture.dragEnd(offsetY: 4, velocityY: 0)))
+        )
+        let hidden = sut.reduce(ended, action: .topBarToggle)
+
+        XCTAssertEqual(hidden.presentation, .browsingHidden)
+    }
+
+    func test_dragEndHighVelocity_hidesChromeOnce_forFastFlick() {
+        let sut = SessionChromeReducer()
+        let dragging = sut.reduce(
+            Fixture.state(showing: .browsingMinimized),
+            action: .webRootScroll(.dragBegan(Fixture.snapshot(offsetY: 0)))
+        )
+        let hidden = sut.reduce(
+            dragging,
+            action: .webRootScroll(.dragEnded(Fixture.dragEnd(offsetY: 4, velocityY: 1_600)))
+        )
+        let stillHidden = sut.reduce(
+            hidden,
+            action: .webRootScroll(.decelerated(Fixture.snapshot(offsetY: 60)))
+        )
+
+        XCTAssertEqual(hidden.presentation, .browsingHidden)
+        XCTAssertEqual(stillHidden.presentation, .browsingHidden)
+    }
+
+    func test_dragEndHighVelocityUp_restoresChromeOnce_forFastFlick() {
+        let sut = SessionChromeReducer()
+        let dragging = sut.reduce(
+            Fixture.state(showing: .browsingHidden),
+            action: .webRootScroll(.dragBegan(Fixture.snapshot(offsetY: 40)))
+        )
+        let minimized = sut.reduce(
+            dragging,
+            action: .webRootScroll(.dragEnded(Fixture.dragEnd(offsetY: 40, velocityY: -1_600)))
+        )
+        let stillMinimized = sut.reduce(
+            minimized,
+            action: .webRootScroll(.decelerated(Fixture.snapshot(offsetY: 0)))
+        )
+
+        XCTAssertEqual(minimized.presentation, .browsingMinimized)
+        XCTAssertEqual(stillMinimized.presentation, .browsingMinimized)
+    }
+
+    func test_dragEndOutOfBoundsWithHighVelocity_keepsChrome_andClearsInteraction() {
+        let sut = SessionChromeReducer()
+        let dragging = sut.reduce(
+            Fixture.state(showing: .browsingMinimized),
+            action: .webRootScroll(.dragBegan(Fixture.snapshot(offsetY: 0)))
+        )
+        let ended = sut.reduce(
+            dragging,
+            action: .webRootScroll(.dragEnded(Fixture.dragEnd(offsetY: -18, velocityY: 1_600)))
+        )
+
+        XCTAssertEqual(ended.presentation, .browsingMinimized)
+        XCTAssertEqual(ended.interaction, .idle)
+    }
+}

--- a/Modules/FeatureSession/Tests/SessionWeb/RootScroll/SessionWebRootScrollPolicyTests.swift
+++ b/Modules/FeatureSession/Tests/SessionWeb/RootScroll/SessionWebRootScrollPolicyTests.swift
@@ -1,0 +1,106 @@
+//
+//  SessionWebRootScrollPolicyTests.swift
+//  Clipy
+//
+//  Created by 박민서 on 7/5/26.
+//
+
+import CoreGraphics
+import XCTest
+
+@testable import FeatureSession
+
+final class SessionWebRootScrollPolicyTests: XCTestCase {
+    func test_dragMovementBeyondThreshold_returnsDirectionAndEligibility_forScrollableRootPage() {
+        let sut = SessionWebRootScrollPolicy()
+
+        let movement = sut.movement(
+            fromAnchorOffsetY: 20,
+            to: snapshot(offsetY: 60)
+        )
+
+        XCTAssertEqual(movement, .init(direction: .down, isEligibleForChromeTransition: true))
+    }
+
+    func test_smallOffsetChange_returnsNil_forBounceNoise() {
+        let sut = SessionWebRootScrollPolicy()
+
+        let movement = sut.movement(
+            fromAnchorOffsetY: 20,
+            to: snapshot(offsetY: 27)
+        )
+
+        XCTAssertNil(movement)
+    }
+
+    func test_topRubberBand_returnsNil_forOutOfBoundsOffset() {
+        let sut = SessionWebRootScrollPolicy()
+
+        let movement = sut.movement(
+            fromAnchorOffsetY: 4,
+            to: snapshot(offsetY: -18)
+        )
+
+        XCTAssertNil(movement)
+    }
+
+    func test_bottomRubberBand_returnsNil_forOutOfBoundsOffset() {
+        let sut = SessionWebRootScrollPolicy()
+
+        let movement = sut.movement(
+            fromAnchorOffsetY: 380,
+            to: snapshot(offsetY: 430)
+        )
+
+        XCTAssertNil(movement)
+    }
+
+    func test_shortRootPage_returnsIneligibleMovement_forChromeReducerGuard() {
+        let sut = SessionWebRootScrollPolicy()
+
+        let movement = sut.movement(
+            fromAnchorOffsetY: 0,
+            to: snapshot(offsetY: 30, contentHeight: 900)
+        )
+
+        XCTAssertEqual(movement, .init(direction: .down, isEligibleForChromeTransition: false))
+    }
+
+    func test_fastFlickMovement_returnsDirectionOnce_fromDragEndVelocity() {
+        let sut = SessionWebRootScrollPolicy()
+
+        let down = sut.flickMovement(from: dragEnd(offsetY: 4, velocityY: 1_600))
+        let up = sut.flickMovement(from: dragEnd(offsetY: 40, velocityY: -1_600))
+        let slow = sut.flickMovement(from: dragEnd(offsetY: 4, velocityY: 800))
+
+        XCTAssertEqual(down, .init(direction: .down, isEligibleForChromeTransition: true))
+        XCTAssertEqual(up, .init(direction: .up, isEligibleForChromeTransition: true))
+        XCTAssertNil(slow)
+    }
+
+    private func snapshot(
+        offsetY: CGFloat,
+        contentHeight: CGFloat = 1_200,
+        viewportHeight: CGFloat = 800,
+        adjustedContentInsetTop: CGFloat = 0,
+        adjustedContentInsetBottom: CGFloat = 0
+    ) -> SessionWebRootScrollSnapshot {
+        SessionWebRootScrollSnapshot(
+            offsetY: offsetY,
+            contentHeight: contentHeight,
+            viewportHeight: viewportHeight,
+            adjustedContentInsetTop: adjustedContentInsetTop,
+            adjustedContentInsetBottom: adjustedContentInsetBottom
+        )
+    }
+
+    private func dragEnd(
+        offsetY: CGFloat,
+        velocityY: CGFloat
+    ) -> SessionWebRootDragEndContext {
+        SessionWebRootDragEndContext(
+            snapshot: snapshot(offsetY: offsetY),
+            velocityY: velocityY
+        )
+    }
+}

--- a/Modules/FeatureSession/Tests/SessionWeb/RootScroll/SessionWebViewRootScrollAdapterTests.swift
+++ b/Modules/FeatureSession/Tests/SessionWeb/RootScroll/SessionWebViewRootScrollAdapterTests.swift
@@ -1,0 +1,97 @@
+//
+//  SessionWebViewRootScrollAdapterTests.swift
+//  Clipy
+//
+//  Created by 박민서 on 7/5/26.
+//
+
+import CoreGraphics
+import XCTest
+
+@testable import FeatureSession
+
+final class SessionWebViewRootScrollAdapterTests: XCTestCase {
+    func test_releaseVelocityY_usesTargetOffsetDirection_forPageDownFlick() {
+        let velocityY = SessionWebRootScrollAdapter.contentVelocityY(
+            releaseVelocityY: -1_600,
+            targetOffsetY: 140,
+            currentOffsetY: 20
+        )
+
+        XCTAssertEqual(velocityY, 1_600)
+    }
+
+    func test_releaseVelocityY_usesTargetOffsetDirection_forPageUpFlick() {
+        let velocityY = SessionWebRootScrollAdapter.contentVelocityY(
+            releaseVelocityY: 1_600,
+            targetOffsetY: 20,
+            currentOffsetY: 140
+        )
+
+        XCTAssertEqual(velocityY, -1_600)
+    }
+
+    func test_releaseVelocityY_returnsZero_whenProjectedOffsetDoesNotMove() {
+        let velocityY = SessionWebRootScrollAdapter.contentVelocityY(
+            releaseVelocityY: 1_600,
+            targetOffsetY: 40,
+            currentOffsetY: 40
+        )
+
+        XCTAssertEqual(velocityY, 0)
+    }
+
+    func test_endDraggingWithoutPreparedTargetOffset_returnsZeroVelocity_forNoFlickFallback() {
+        let sut = SessionWebRootScrollAdapter()
+        let snapshot = snapshot(offsetY: 20)
+
+        _ = sut.beginDragging(snapshot: snapshot)
+        let input = sut.endDragging(snapshot: snapshot)
+
+        XCTAssertEqual(
+            input,
+            .dragEnded(SessionWebRootDragEndContext(snapshot: snapshot, velocityY: 0))
+        )
+    }
+
+    func test_beginDraggingClearsPreparedVelocity_forInterruptedPreviousDrag() {
+        let sut = SessionWebRootScrollAdapter()
+        let snapshot = snapshot(offsetY: 20)
+
+        _ = sut.beginDragging(snapshot: snapshot)
+        sut.prepareDragEnd(
+            releaseVelocityY: 1_600,
+            targetOffsetY: 140,
+            currentOffsetY: 20
+        )
+        _ = sut.beginDragging(snapshot: snapshot)
+        let input = sut.endDragging(snapshot: snapshot)
+
+        XCTAssertEqual(
+            input,
+            .dragEnded(SessionWebRootDragEndContext(snapshot: snapshot, velocityY: 0))
+        )
+    }
+
+    func test_scrollInputAfterEndDragging_returnsExternalScroll_forProgrammaticFollowUp() {
+        let sut = SessionWebRootScrollAdapter()
+        let currentSnapshot = snapshot(offsetY: 20)
+        let followUpSnapshot = snapshot(offsetY: 44)
+
+        _ = sut.beginDragging(snapshot: currentSnapshot)
+        _ = sut.endDragging(snapshot: currentSnapshot)
+        let input = sut.scrollInput(snapshot: followUpSnapshot)
+
+        XCTAssertEqual(input, .externalScroll(followUpSnapshot))
+    }
+
+    private func snapshot(offsetY: CGFloat) -> SessionWebRootScrollSnapshot {
+        SessionWebRootScrollSnapshot(
+            offsetY: offsetY,
+            contentHeight: 1_200,
+            viewportHeight: 800,
+            adjustedContentInsetTop: 0,
+            adjustedContentInsetBottom: 0
+        )
+    }
+}


### PR DESCRIPTION
  ## 무엇을 바꿨나요?

  이전 PR에서는 WebView의 raw scroll callback을 바로 chrome 상태 전환에 쓰지 않고, 
  Session 화면이 이해할 수 있는 root scroll 입력으로 분리했습니다.

  본 PR은 그 다음 단계로, TopBar toggle, BottomSheet 상태, Web root scroll 입력을 판단하는 `SessionChromeReducer`을 작성합니다.

  ```mermaid
  ---
  title: Session chrome stacked PR 흐름
  ---
  graph LR
    PR1[PR1 화면/객체 파일 구조 정리] --> PR2[PR2 Web root scroll 입력 분리]
    PR2 --> PR3[PR3 Session chrome reducer 추가]
    PR3 --> PR4[PR4 ViewModel binding 연결]
  ```

  ```mermaid
  ---
  title: Session chrome 전환 판단 위치
  ---
  graph LR
    TopBar[TopBar toggle] --> Reducer[SessionChromeReducer]
    BottomSheet[BottomSheet state] --> Reducer
    WebRoot[Web root scroll] --> Reducer
    Reducer --> ChromeState[SessionChromeState]
  ```

  ## 왜 바꿨나요?

  Session chrome 전환은 단일 입력만 보고 결정하기 어렵습니다.

  TopBar 버튼은 사용자가 명시적으로 누른 입력이고, WebView scroll은 드래그 중 여러 callback으로 들어오며, BottomSheet 상태는 화면에서 chrome이 어느 정도 드러나야 하는지에 영향을 줍니다. 
  이 판단이 각 View나 ViewModel에 흩어지면 어떤 입력이 우선인지 추적하기 어려워집니다.
  그래서 이 PR에서는 chrome 상태를 바꿀 수 있는 권한들을 reducer에 모았습니다.
  WebView는 scroll 입력을 만들고, TopBar와 BottomSheet는 action을 전달하며, 실제 전환 여부는`SessionChromeReducer`가 판단합니다.

  ## 변경 범위

  - Session chrome 상태와 action 모델을 추가했습니다.
  - Web root drag 중인지 판단하는 interaction state를 추가했습니다.
  - `SessionChromeReducer`가 chrome 전환 규칙을 한 곳에서 처리하게 했습니다.
  - TopBar toggle, BottomSheet 상태, Web root scroll 입력 충돌을 테스트로 고정했습니다.

  ## 제외한 범위

  - 이 PR에서는 ViewModel binding까지 연결하지 않습니다.
  - BottomSheet active dragging 세부 정책은 후속 작업으로 둡니다.
  - viewport/inset 재설계는 후속 작업으로 둡니다.
  - 외부 웹사이트의 custom scroll container 대응은 포함하지 않았습니다.

  ## 확인한 내용

  실제로 확인한 항목만 체크했습니다.

  - [x] 전체 stack 기준 `CLIPY_IOS_VALIDATION_PROFILE=module
  CLIPY_IOS_VALIDATION_SCHEMES=FeatureSession CLIPY_IOS_VALIDATION_MODE=test ./scripts/
  validate_ios_profile.sh` 통과
  - [x] 생성된 `.xcodeproj`, `.xcworkspace`, `Derived/` 미포함 확인
  - [x] PR3 범위 `git diff --check` 통과

  ## 테스트와 문서

  `SessionChromeReducerTests`와 `SessionChromeReducerWebRootScrollTests`를 추가했습니다.

  테스트는 chrome 상태 전환 권한이 reducer에 모여 있는지, active web root drag 중 TopBar toggle을 무시하는지, deceleration callback이 자동 전환 권한을 갖지 않는지 확인합니다.

  ## 리뷰어가 특히 봐야 할 부분
  - chrome 상태를 바꾸는 판단이 `SessionChromeReducer`를 우회하지 않는지 봐주세요.
  - active web root drag 중 TopBar toggle을 무시하는 규칙이 현재 UX 기준에 맞는지 봐주세요.
  - fast flick를 drag end 시점의 1회 판단으로 보는 방향이 과하거나 부족하지 않은지 봐주세요.

  ## 관련 이슈

  Related: #25
  Related: CLIPY-72
